### PR TITLE
Support for UUIDs and case-sensitive DB table names

### DIFF
--- a/django_multitenant/django_multitenant.py
+++ b/django_multitenant/django_multitenant.py
@@ -18,15 +18,17 @@ class TenantQuerySet(models.QuerySet):
     def add_tenant_filters_with_joins(self):
         current_tenant=get_current_tenant()
         if current_tenant:
-            l=[]
+            extra_sql=[]
+            extra_params=[]
             current_table_name=self.model._meta.db_table
             alias_refcount = self.query.alias_refcount
             alias_map = self.query.alias_map
             for k,v in alias_refcount.items():
                 if(v>0 and k!=current_table_name):
                     current_model=get_model_by_db_table(alias_map[k].table_name)
-                    l.append(k+'.'+current_model.tenant_id+'='+str(current_tenant.id))
-            self.query.add_extra([],[],l,[],[],[])
+                    extra_sql.append(k+'.'+current_model.tenant_id+' = %s')
+                    extra_params.append(current_tenant.id)
+            self.query.add_extra([],[],extra_sql,extra_params,[],[])
     
     def add_tenant_filters_without_joins(self):
         current_tenant=get_current_tenant()

--- a/django_multitenant/django_multitenant.py
+++ b/django_multitenant/django_multitenant.py
@@ -26,7 +26,7 @@ class TenantQuerySet(models.QuerySet):
             for k,v in alias_refcount.items():
                 if(v>0 and k!=current_table_name):
                     current_model=get_model_by_db_table(alias_map[k].table_name)
-                    extra_sql.append(k+'.'+current_model.tenant_id+' = %s')
+                    extra_sql.append('"'+k+'"."'+current_model.tenant_id+'" = %s')
                     extra_params.append(current_tenant.id)
             self.query.add_extra([],[],extra_sql,extra_params,[],[])
     


### PR DESCRIPTION
Before:
```sql
SELECT ... WHERE ... AND (my_model.tenant_id=3f3a8c4b-cc58-439e-9266-0290cec249e2)
-- ERROR:  syntax error at or near "f3a8c4b" at character 464
```

After:
```sql
SELECT ... WHERE ... AND ("my_model"."tenant_id" = '3f3a8c4b-cc58-439e-9266-0290cec249e2'::uuid)
```