### PR TITLE
Wrapping table name in quotes breaks table aliases

### DIFF
--- a/django_multitenant/django_multitenant.py
+++ b/django_multitenant/django_multitenant.py
@@ -26,7 +26,7 @@ class TenantQuerySet(models.QuerySet):
             for k,v in alias_refcount.items():
                 if(v>0 and k!=current_table_name):
                     current_model=get_model_by_db_table(alias_map[k].table_name)
-                    extra_sql.append('"'+k+'"."'+current_model.tenant_id+'" = %s')
+                    extra_sql.append(k+'."'+current_model.tenant_id+'" = %s')
                     extra_params.append(current_tenant.id)
             self.query.add_extra([],[],extra_sql,extra_params,[],[])
     


### PR DESCRIPTION
Expected query:
```sql
SELECT "foo"."id",
       T3."name"
FROM "foo"
INNER JOIN "bar" T3 ON ("foo"."bar_id" = T3."id")
WHERE ("foo"."tenant_id" = 1
       AND "foo"."bar_id" = 2
       AND T3."tenant_id" = 1);
```

Observed query:
```sql
SELECT "foo"."id",
       T3."name"
FROM "foo"
INNER JOIN "bar" T3 ON ("foo"."bar_id" = T3."id")
WHERE ("foo"."tenant_id" = 1
       AND "foo"."bar_id" = 2
       AND "T3"."tenant_id" = 1);   -- quotes around "T3" here breaks table alias
```