### PR TITLE
fix #10 relative import for python less than 3

### DIFF
--- a/django_multitenant/__init__.py
+++ b/django_multitenant/__init__.py
@@ -1,1 +1,6 @@
-from django_multitenant.django_multitenant import *
+import sys
+
+if sys.version_info >= (3,0):
+    from django_multitenant.django_multitenant import *
+else:
+    from .django_multitenant import *


### PR DESCRIPTION
Change top-level `__init__.py` to be compatible with python 2.
Closes : #10 