### PR TITLE
Update django-multitenant to support Citus and automatic Django migrations

### DIFF
--- a/django_multitenant/backends/postgresql/base.py
+++ b/django_multitenant/backends/postgresql/base.py
@@ -1,44 +1,33 @@
 import logging
-from django.apps import apps
+from django.conf import settings
+from django.db import connections
 from django.db.backends.postgresql.base import (
     DatabaseWrapper as PostgresqlDatabaseWrapper,
     DatabaseSchemaEditor as PostgresqlDatabaseSchemaEditor,
-    DatabaseCreation,
-    DatabaseFeatures,
-    DatabaseOperations,
-    DatabaseClient,
-    DatabaseIntrospection
+    DatabaseCreation as PostgresqlDatabaseCreation,
 )
-from django_multitenant.fields import TenantForeignKey
-from django_multitenant.utils import get_model_by_db_table, get_tenant_column
+from django_multitenant.fields import (
+    TenantForeignKey,
+    TenantPrimaryKey,
+    TenantOneToOneField,
+)
+from django_multitenant.mixins import TenantModelMixin
+from django_multitenant.utils import (
+    get_model_by_db_table,
+    get_tenant_column,
+    get_tenant_field,
+)
 
 logger = logging.getLogger(__name__)
 
 
 class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
     # Override
-    def __enter__(self):
+    def __enter__(self, *args, **kwargs):
+        self.table_distribution_sql = []
+        self.composite_constraints_sql = []
         ret = super(DatabaseSchemaEditor, self).__enter__()
         return ret
-
-    # Override
-    def _alter_field(self, model, old_field, new_field, old_type, new_type,
-                     old_db_params, new_db_params, strict=False):
-
-        super(DatabaseSchemaEditor, self)._alter_field(model, old_field,
-                                                       new_field, old_type,
-                                                       new_type, old_db_params,
-                                                       new_db_params, strict)
-
-        # If the pkey was dropped in the previous distribute migration,
-        # foreign key constraints didn't previously exists so django does not
-        # recreated them.
-        # Here we test if we are in this case
-        if isinstance(new_field, TenantForeignKey) and new_field.db_constraint:
-            fk_names = self._constraint_names(model, [new_field.column], foreign_key=True)
-            if not fk_names:
-                self.execute(self._create_fk_sql(model, new_field,
-                                                 "_fk_%(to_table)s_%(to_column)s"))
 
     # Override
     def _create_fk_sql(self, model, field, suffix):
@@ -48,7 +37,9 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
                 # This case happens when we are running from scratch migrations and one model was removed from code
                 # In the previous migrations we would still be creating the foreign key
                 from_model = get_model_by_db_table(model._meta.db_table)
-                to_model = get_model_by_db_table(field.target_field.model._meta.db_table)
+                to_model = get_model_by_db_table(
+                    field.target_field.model._meta.db_table
+                )
             except ValueError:
                 return None
 
@@ -56,15 +47,21 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
             to_columns = field.target_field.column, get_tenant_column(to_model)
             suffix = suffix % {
                 "to_table": field.target_field.model._meta.db_table,
-                "to_column": '_'.join(to_columns),
+                "to_column": "_".join(to_columns),
             }
 
             return self.sql_create_fk % {
                 "table": self.quote_name(model._meta.db_table),
-                "name": self.quote_name(self._create_index_name(model, from_columns, suffix=suffix)),
-                "column": ', '.join([self.quote_name(from_col) for from_col in from_columns]),
+                "name": self.quote_name(
+                    self._create_index_name(model, from_columns, suffix=suffix)
+                ),
+                "column": ", ".join(
+                    [self.quote_name(from_col) for from_col in from_columns]
+                ),
                 "to_table": self.quote_name(field.target_field.model._meta.db_table),
-                "to_column": ', '.join([self.quote_name(to_col) for to_col in to_columns]),
+                "to_column": ", ".join(
+                    [self.quote_name(to_col) for to_col in to_columns]
+                ),
                 "deferrable": self.connection.ops.deferrable_sql(),
             }
         return super(DatabaseSchemaEditor, self)._create_fk_sql(model, field, suffix)
@@ -74,12 +71,11 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
         # Hack: Citus will throw the following error if these statements are
         # not executed separately: "ERROR: cannot execute multiple utility events"
         if sql and not params:
-            for statement in str(sql).split(';'):
+            for statement in str(sql).split(";"):
                 if statement and not statement.isspace():
                     super(DatabaseSchemaEditor, self).execute(statement)
         elif sql:
             super(DatabaseSchemaEditor, self).execute(sql, params)
-
 
     def _create_index_name(self, model, column_names, suffix=""):
         # compat with django 2.X and django 1.X
@@ -88,11 +84,215 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
         if not isinstance(model, str) and django.VERSION[0] > 1:
             model = model._meta.db_table
 
-        return super(DatabaseSchemaEditor, self)._create_index_name(model,
-                                                                    column_names,
-                                                                    suffix=suffix)
+        return super(DatabaseSchemaEditor, self)._create_index_name(
+            model, column_names, suffix=suffix
+        )
+
+    # Override
+    def column_sql(self, model, field, include_default=False):
+        if isinstance(field, TenantPrimaryKey):
+            # We can't create a primary key over one column in our sharded setup,
+            # but Django needs to believe we have a primary key, so only remove it now that we're actually writing SQL,
+            # and add the correct constraint in create_model below.
+            field.primary_key = False
+        elif isinstance(field, TenantOneToOneField):
+            # OneToOneFields write a UNIQUE column, but this isn't possible with our sharding, so remove it
+            # and add the correct constraint in create_model below.
+            field._unique = False
+            # OneToOneFields write a Foreign Key constraint, which would require the field we point to to be unique.
+            # Obviously it can't be, due to sharding, so opt out of this constraint.
+            field.db_constraint = False
+        sql, params = super().column_sql(model, field, include_default)
+        return sql, params
+
+    # Override
+    def create_model(self, model):
+        super().create_model(model)
+        table_name = model._meta.db_table
+        quoted_table_name = self.quote_name(table_name)
+
+        for field in model._meta.local_fields:
+            if isinstance(field, TenantPrimaryKey):
+                quoted_tenant_column = self.quote_name(field.tenant_id)
+                constraint_name = self.quote_name(f"{table_name}_pkey")
+                self.composite_constraints_sql.extend(
+                    [
+                        f"""
+                    ---
+                    --- Add composite primary key to {table_name}
+                    ---
+                    ALTER TABLE {quoted_table_name}
+                    ADD CONSTRAINT {constraint_name}
+                    PRIMARY KEY ({quoted_tenant_column}, id)
+                    """
+                    ]
+                )
+            elif isinstance(field, TenantOneToOneField):
+                tenant_column = field.tenant_id
+                quoted_tenant_column = self.quote_name(tenant_column)
+                one_to_one_column = field.column
+                quoted_one_to_one_column = self.quote_name(one_to_one_column)
+                constraint_name = self.quote_name(
+                    self._create_index_name(
+                        table_name, (tenant_column, one_to_one_column), "_uniq"
+                    )
+                )
+                self.composite_constraints_sql.extend(
+                    [
+                        f"""
+                    ---
+                    --- Add composite constraint for onetoonefield to {table_name}
+                    ---
+                    ALTER TABLE {quoted_table_name}
+                    ADD CONSTRAINT {constraint_name}
+                    UNIQUE ({quoted_tenant_column}, {quoted_one_to_one_column})
+                    """
+                    ]
+                )
+
+        if issubclass(model, TenantModelMixin):
+            if table_name == "core_brand":
+                # Brand is distributed, but has no TenantPrimaryKey, as it is the model the other tenants are based on.
+                distribution_column_name = "id"
+            else:
+                distribution_column_name = get_tenant_field(model)
+            self.table_distribution_sql.extend(
+                [
+                    f"""
+                ---
+                --- Register {table_name} as a distributed (sharded) table
+                ---
+                SELECT CREATE_DISTRIBUTED_TABLE('{table_name}', '{distribution_column_name}');
+                """
+                ]
+            )
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # We need to ensure our tables are distributed correctly before we try to apply constraints,
+        # as otherwise we'd end up trying to apply constraints between distributed and local tables, which is invalid.
+        if exc_type is None:
+            for sql in self.table_distribution_sql:
+                self.execute(sql)
+            for sql in self.composite_constraints_sql:
+                self.execute(sql)
+        return super().__exit__(exc_type, exc_value, traceback)
+
+
+class TestDBCursor(object):
+    def __init__(self, connection, test_db_name):
+        self.connection = connection
+        self.cursor = None
+        self.current_db_name = settings.DATABASES[self.connection.alias]["NAME"]
+
+        self.test_database_name = test_db_name
+
+    def __enter__(self):
+        self.connection.close()
+        settings.DATABASES[self.connection.alias]["NAME"] = self.test_database_name
+        self.connection.settings_dict["NAME"] = self.test_database_name
+        self.cursor = connections[self.connection.alias].cursor()
+        return self.cursor
+
+    def __exit__(self, *args):
+        self.connection.close()
+        self.cursor = None
+
+
+class DatabaseCreation(PostgresqlDatabaseCreation):
+    def _execute_create_test_db(self, cursor, *args, **kwargs):
+        super()._execute_create_test_db(cursor, *args, **kwargs)
+        cursor.execute(
+            f"SELECT success FROM RUN_COMMAND_ON_WORKERS('CREATE DATABASE {self._get_test_db_name()}')"
+        )
+        success = cursor.fetchone()[0]
+        if not success:
+            raise ValueError("DB already exists on worker")
+
+    def _create_test_db(self, verbosity, autoclobber, keepdb=False):
+        """
+        Internal implementation - create the test db tables.
+        """
+        test_database_name = self._get_test_db_name()
+        test_db_params = {
+            "dbname": self.connection.ops.quote_name(test_database_name),
+            "suffix": self.sql_table_creation_suffix(),
+        }
+        worker_details = []
+
+        # Create the test database and connect to it.
+        with self._nodb_connection.cursor() as cursor:
+            try:
+                self._execute_create_test_db(cursor, test_db_params, keepdb)
+            except Exception as e:
+                # if we want to keep the db, then no need to do any of the below,
+                # just return and skip it all.
+                if keepdb:
+                    return test_database_name
+
+                self.log("Got an error creating the test database: %s" % e)
+                if not autoclobber:
+                    confirm = input(
+                        "Type 'yes' if you would like to try deleting the test "
+                        "database '%s', or 'no' to cancel: " % test_database_name
+                    )
+                if autoclobber or confirm == "yes":
+                    try:
+                        if verbosity >= 1:
+                            self.log(
+                                "Destroying old test database for alias %s..."
+                                % (
+                                    self._get_database_display_str(
+                                        verbosity, test_database_name
+                                    ),
+                                )
+                            )
+                        db_name = test_db_params["dbname"]
+                        cursor.execute(
+                            f"SELECT * FROM run_command_on_workers('DROP DATABASE IF EXISTS {db_name}')"
+                        )
+                        cursor.execute(f"DROP DATABASE IF EXISTS {db_name}")
+                        self._execute_create_test_db(cursor, test_db_params, keepdb)
+                    except Exception as e:
+                        self.log("Got an error recreating the test database: %s" % e)
+                        sys.exit(2)
+                else:
+                    self.log("Tests cancelled.")
+                    sys.exit(1)
+
+            # Fetch worker details from the existing database on master, so we can set the up on the new database
+            cursor.execute("SELECT MASTER_GET_ACTIVE_WORKER_NODES()")
+            worker_strings = cursor.fetchall()
+            # MASTER_ADD_NODES returns a list of one-tuples of strings of the form '(citus_worker_1, 5432)'
+            worker_details = [
+                worker_row[0].strip("(").strip(")").split(",")
+                for worker_row in worker_strings
+            ]
+
+        with TestDBCursor(self.connection, test_database_name) as cursor:
+            # Install citus on the test db master
+            cursor.execute("CREATE EXTENSION IF NOT EXISTS citus;")
+            # Connect worker with master db
+            for worker_name, worker_port in worker_details:
+                # Make the test database on master aware of the worker
+                cursor.execute(
+                    f"SELECT * FROM MASTER_ADD_NODE('{worker_name}', {worker_port});"
+                )
+            cursor.execute(
+                f"SELECT RUN_COMMAND_ON_WORKERS($cmd$ CREATE EXTENSION IF NOT EXISTS citus; $cmd$)"
+            )
+
+        return test_database_name
+
+    def _destroy_test_db(self, test_database_name, verbosity):
+        test_db_name = self.connection.ops.quote_name(test_database_name)
+        with self.connection._nodb_connection.cursor() as cursor:
+            cursor.execute(f"DROP DATABASE {test_db_name}")
+            cursor.execute(
+                f"SELECT RUN_COMMAND_ON_WORKERS('DROP DATABASE {test_db_name}')"
+            )
 
 
 class DatabaseWrapper(PostgresqlDatabaseWrapper):
     # Override
     SchemaEditorClass = DatabaseSchemaEditor
+    creation_class = DatabaseCreation

--- a/django_multitenant/backends/postgresql/base.py
+++ b/django_multitenant/backends/postgresql/base.py
@@ -13,11 +13,7 @@ from django_multitenant.fields import (
     TenantOneToOneField,
 )
 from django_multitenant.mixins import TenantModelMixin
-from django_multitenant.utils import (
-    get_model_by_db_table,
-    get_tenant_column,
-    get_tenant_column,
-)
+from django_multitenant.utils import get_model_by_db_table, get_tenant_column
 
 logger = logging.getLogger(__name__)
 

--- a/django_multitenant/backends/postgresql/base.py
+++ b/django_multitenant/backends/postgresql/base.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from django.conf import settings
 from django.db import connections
 from django.db.backends.postgresql.base import (

--- a/django_multitenant/backends/postgresql/base.py
+++ b/django_multitenant/backends/postgresql/base.py
@@ -16,7 +16,7 @@ from django_multitenant.mixins import TenantModelMixin
 from django_multitenant.utils import (
     get_model_by_db_table,
     get_tenant_column,
-    get_tenant_field,
+    get_tenant_column,
 )
 
 logger = logging.getLogger(__name__)
@@ -167,7 +167,7 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
                 )
 
         if issubclass(model, TenantModelMixin):
-            distribution_column_name = get_tenant_field(model)
+            distribution_column_name = get_tenant_column(model)
             self.execute(
                 f"""
                 ---

--- a/django_multitenant/models.py
+++ b/django_multitenant/models.py
@@ -2,27 +2,25 @@ import logging
 
 from django.db import models
 
-from .mixins import (TenantManagerMixin,
-                     TenantModelMixin)
+from .mixins import TenantManagerMixin, TenantModelMixin
 
 from .utils import (
     set_current_tenant,
     get_current_tenant,
     get_model_by_db_table,
-    get_tenant_column
+    get_tenant_column,
 )
 
 logger = logging.getLogger(__name__)
 
 
-
 class TenantManager(TenantManagerMixin, models.Manager):
-    #Below is the manager related to the above class.
+    # Below is the manager related to the above class.
     pass
 
 
 class TenantModel(TenantModelMixin, models.Model):
-    #Abstract model which all the models related to tenant inherit.
+    # Abstract model which all the models related to tenant inherit.
 
     objects = TenantManager()
 

--- a/django_multitenant/query.py
+++ b/django_multitenant/query.py
@@ -6,15 +6,13 @@ from .utils import get_current_tenant, get_tenant_column, get_tenant_filters
 
 def wrap_get_compiler(base_get_compiler):
     def get_compiler(obj, *args, **kwargs):
-        # current_tenant = get_current_tenant()
-        # if current_tenant:
-        #     try:
-        #         filters = get_tenant_filters(obj.model)
-        #         obj.add_q(Q(
-        #             **filters
-        #         ))
-        #     except ValueError:
-        #         pass
+        current_tenant = get_current_tenant()
+        if current_tenant:
+            try:
+                filters = get_tenant_filters(obj.model)
+                obj.add_q(Q(**filters))
+            except ValueError:
+                pass
         return base_get_compiler(obj, *args, **kwargs)
 
     get_compiler._sign = "get_compiler django-multitenant"

--- a/django_multitenant/query.py
+++ b/django_multitenant/query.py
@@ -5,19 +5,16 @@ from .utils import get_current_tenant, get_tenant_column, get_tenant_filters
 
 
 def wrap_get_compiler(base_get_compiler):
-
     def get_compiler(obj, *args, **kwargs):
-        current_tenant = get_current_tenant()
-
-        if current_tenant:
-            try:
-                filters = get_tenant_filters(obj.model)
-                obj.add_q(Q(
-                    **filters
-                ))
-            except ValueError:
-                pass
-
+        # current_tenant = get_current_tenant()
+        # if current_tenant:
+        #     try:
+        #         filters = get_tenant_filters(obj.model)
+        #         obj.add_q(Q(
+        #             **filters
+        #         ))
+        #     except ValueError:
+        #         pass
         return base_get_compiler(obj, *args, **kwargs)
 
     get_compiler._sign = "get_compiler django-multitenant"

--- a/django_multitenant/utils.py
+++ b/django_multitenant/utils.py
@@ -17,7 +17,7 @@ def get_current_user():
     logged in user, even if the request object is not in scope.  The best way to do this is
     by storing the user object in middleware while processing the request.
     """
-    return getattr(_thread_locals, 'user', None)
+    return getattr(_thread_locals, "user", None)
 
 
 def get_model_by_db_table(db_table):
@@ -26,7 +26,7 @@ def get_model_by_db_table(db_table):
             return model
     else:
         # here you can do fallback logic if no model with db_table found
-        raise ValueError('No model found with db_table {}!'.format(db_table))
+        raise ValueError("No model found with db_table {}!".format(db_table))
         # or return None
 
 
@@ -37,7 +37,7 @@ def get_current_tenant():
         tenant = get_current_tenant()
     """
     # tenant may not be set yet, if request user is anonymous, or has no profile,
-    return getattr(_thread_locals, 'tenant', None)
+    return getattr(_thread_locals, "tenant", None)
 
 
 def get_tenant_column(model_class_or_instance):
@@ -47,19 +47,20 @@ def get_tenant_column(model_class_or_instance):
     try:
         return model_class_or_instance.tenant_field
     except:
-        raise ValueError('''%s is not an instance or a subclass of TenantModel
-                         or does not inherit from TenantMixin'''
-                         % model_class_or_instance.__class__.__name__)
+        raise ValueError(
+            """%s is not an instance or a subclass of TenantModel
+                         or does not inherit from TenantMixin"""
+            % model_class_or_instance.__class__.__name__
+        )
 
 
 def get_tenant_field(model_class_or_instance):
-    tenant_column = get_tenant_column(model_class_or_instance)
-    all_fields = model_class_or_instance._meta.fields
-    try:
-        return next(field for field in all_fields if field.column == tenant_column)
-    except StopIteration:
-        raise ValueError('No field found in {} with column name "{}"'.format(
-                         model_class_or_instance, tenant_column))
+    from .fields import TenantPrimaryKey
+
+    for field in model_class_or_instance._meta.fields:
+        if isinstance(field, TenantPrimaryKey):
+            return field.tenant_id
+    raise ValueError(f"{model_class_or_instance} has no TenantPrimaryKey")
 
 
 def get_current_tenant_value():
@@ -87,7 +88,7 @@ def get_tenant_filters(table, filters=None):
         return filters
 
     if isinstance(current_tenant_value, list):
-        filters['%s__in' % get_tenant_column(table)] = current_tenant_value
+        filters["%s__in" % get_tenant_column(table)] = current_tenant_value
     else:
         filters[get_tenant_column(table)] = current_tenant_value
 
@@ -95,8 +96,8 @@ def get_tenant_filters(table, filters=None):
 
 
 def set_current_tenant(tenant):
-    setattr(_thread_locals, 'tenant', tenant)
+    setattr(_thread_locals, "tenant", tenant)
 
 
 def unset_current_tenant():
-    setattr(_thread_locals, 'tenant', None)
+    setattr(_thread_locals, "tenant", None)

--- a/django_multitenant/utils.py
+++ b/django_multitenant/utils.py
@@ -41,20 +41,6 @@ def get_current_tenant():
 
 
 def get_tenant_column(model_class_or_instance):
-    if inspect.isclass(model_class_or_instance):
-        model_class_or_instance = model_class_or_instance()
-
-    try:
-        return model_class_or_instance.tenant_field
-    except:
-        raise ValueError(
-            """%s is not an instance or a subclass of TenantModel
-                         or does not inherit from TenantMixin"""
-            % model_class_or_instance.__class__.__name__
-        )
-
-
-def get_tenant_field(model_class_or_instance):
     from .fields import TenantPrimaryKey
 
     for field in model_class_or_instance._meta.fields:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 psycopg2
-Django==1.11.20
+Django>=1.11.21, <2.0
 tox
 pytest
 pytest-cov

--- a/test_app/requirements.txt
+++ b/test_app/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.20
+Django>=1.11.21, <2.0
 django-money==0.9.1
 django-simple-multitenant==0.1.0
 psycopg2==2.6.2


### PR DESCRIPTION
Opening this up largely for discussion, it's not yet merge-ready. The issues that me and my team have been having is that while this library is a good first-step towards moving to Citus it isn't currently complete enough to use comfortably for day-to-day development.

Our changes include:
1. Automatic creation of a composite primary keys in migrations.
2. Making sure migrations are fully forwards and backwards compatible.
3. Automatically running the right Citus commands when creating tables.
4. Full compatibility with the Django test framework when running tests against a Citus cluster (Locally running one in Docker).

Perhaps some of these things are beyond the scope of this library, others may just need to be turned on or off by settings flags, but I think what we're really wanting is a something that makes it as straightforward as possible to use Citus and Django together not just as an initial migration but on a living project where models are continually added and schemas altered.

