### PR TITLE
Disable create column inline fk

### DIFF
--- a/django_multitenant/backends/postgresql/base.py
+++ b/django_multitenant/backends/postgresql/base.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
+
+    sql_create_column_inline_fk = None
     # Override
     def __enter__(self):
         ret = super(DatabaseSchemaEditor, self).__enter__()


### PR DESCRIPTION
Django 3.0 postgresql backend now attempts to create ForeignKey constraints without going through `self._create_fk_sql` that is overwritten by this package to construct the constraint https://github.com/django/django/blob/3.0.10/django/db/backends/base/schema.py#L461
https://github.com/django/django/blob/a208020ecd0aa568cb5be6ef8b76701224ebe1a2/django/db/backends/postgresql/schema.py#L24

This causes error in https://github.com/citusdata/django-multitenant/issues/94