### PR TITLE
Update versions throughout the repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: required
+dist: bionic # Not using focal yet, because Python 2.7 is not available there
 language: python
-python: 3.7
+python: 3.9
 
 env:
   - PREPARED_STATEMENTS=0
@@ -11,11 +11,11 @@ services:
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
   - docker-compose --version
-  - docker-compose --project-name django-multitenant up -d
+  - docker-compose --project-name django-multitenant up -d || { docker-compose logs && false ; }
   - docker-compose -f ./single-node-docker-compose.yml --project-name django-multitenant up -d
 
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ https://www.citusdata.com/blog/2016/10/03/designing-your-saas-database-for-high-
 | Python        | Django        |
 | ------------- | -------------:|
 | 2.7           | 1.11          |
-| 3.X           | 2.0           |
-| 3.X           | 2.1           |
 | 3.X           | 2.2           |
-| 3.X           | 3.0           |
+| 3.X           | 3.1           |
+| 3.X           | 3.2           |
 
 
 ## Usage:

--- a/django_multitenant/tests/test_models.py
+++ b/django_multitenant/tests/test_models.py
@@ -1,5 +1,7 @@
 import re
 
+import django
+import pytest
 from django.conf import settings
 from django.db.utils import NotSupportedError, DataError
 
@@ -415,6 +417,8 @@ class TenantModelTest(BaseTestCase):
         tasks = Task.objects.exclude(project__isnull=True)
         self.assertEqual(tasks.count(), 150)
 
+    @pytest.mark.skipif(not django.VERSION < (3, 2),
+                        reason="Django 3.2 changed the generated query to one that's not supported by Citus")
     def test_exclude_related(self):
         from .models import Project, Manager, ProjectManager
         project = self.projects[0]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,19 +3,25 @@ version: '2.1'
 services:
   master:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_master"
-    image: 'citusdata/citus:9.0.1'
+    image: 'citusdata/citus:10.2.2'
     ports: ['5600:5432']
     labels: ['com.citusdata.role=Master']
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
   worker1:
-    image: 'citusdata/citus:9.0.1'
+    image: 'citusdata/citus:10.2.2'
     ports: ['5601:5432']
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
   worker2:
-    image: 'citusdata/citus:9.0.1'
+    image: 'citusdata/citus:10.2.2'
     ports: ['5602:5432']
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
   manager:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
     image: 'citusdata/membership-manager:0.2.0'

--- a/single-node-docker-compose.yml
+++ b/single-node-docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   db:
-    image: "postgres:11"
+    image: "postgres:14"
     container_name: "${COMPOSE_PROJECT_NAME:-single}_node_postgres"
     ports:
       - "5604:5432"

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,21 @@
 [tox]
 envlist =
     {py27}-django{111}
-    {py37}-django{20}
-    {py37}-django{21}
-    {py37}-django{22}
-    {py37}-django{30}
-    {py37}-django{31}
+    {py39}-django{22}
+    {py39}-django{31}
+    {py39}-django{32}
 
 [testenv]
 basepython =
     py27: python2.7
-    py37: python3.7
+    py39: python3.9
 
 deps =
     -r{toxinidir}/requirements/tox.txt
     {py27}-django111: Django>=1.11,<2.0
-    {py37}-django20: Django>=2.0,<2.1
-    {py37}-django21: Django>=2.1,<2.1.6
-    {py37}-django22: Django>=2.2,<3.0
-    {py37}-django30: Django>=3.0,<3.1
-    {py37}-django31: Django>=3.1
+    {py39}-django22: Django>=2.2,<3.0
+    {py39}-django31: Django>=3.1,<3.2
+    {py39}-django32: Django>=3.2,<3.3
 
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
This tests that we support newer Django, Python and Citus versions and
drops support for Django versions that have reached upstream EOL.

The only EOL version that we still test against is django 1.11, because
that's the last one to support Python 2.7. I'm pretty sure some people
still use this even though they shouldn't. So let's try to keep
supporting it for now.