### PR TITLE
Disable fsync for our test docker compose cluster

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     labels: ['com.citusdata.role=Master']
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
+    command: -c fsync=off -c full_page_writes=off
   worker1:
     image: 'citusdata/citus:10.2.2'
     ports: ['5601:5432']
@@ -15,6 +16,7 @@ services:
     depends_on: { manager: { condition: service_healthy } }
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
+    command: -c fsync=off -c full_page_writes=off
   worker2:
     image: 'citusdata/citus:10.2.2'
     ports: ['5602:5432']
@@ -22,6 +24,7 @@ services:
     depends_on: { manager: { condition: service_healthy } }
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
+    command: -c fsync=off -c full_page_writes=off
   manager:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
     image: 'citusdata/membership-manager:0.2.0'


### PR DESCRIPTION
This significantly speeds up running of tests on my local machine. We
don't need strict data durability in our docker compose cluster. If your
machine crashes we can just rerun the tests or recreate the docker
compose cluster if needed.