### PR TITLE
Fix aggregation with annotate

### DIFF
--- a/django_multitenant/backends/postgresql/base.py
+++ b/django_multitenant/backends/postgresql/base.py
@@ -1,6 +1,7 @@
 import logging
 from django.apps import apps
 from django.db.backends.postgresql.base import (
+    DatabaseFeatures as PostgresqlDatabaseFeatures,
     DatabaseWrapper as PostgresqlDatabaseWrapper,
     DatabaseSchemaEditor as PostgresqlDatabaseSchemaEditor,
     DatabaseCreation,
@@ -101,7 +102,13 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
                                                                     column_names,
                                                                     suffix=suffix)
 
+class DatabaseFeatures(PostgresqlDatabaseFeatures):
+    # The default Django behaviour is to collapse the fields to just the 'id' field
+    # This doesn't work because we're using a composite primary key.
+    allows_group_by_selected_pks = False
+
 
 class DatabaseWrapper(PostgresqlDatabaseWrapper):
     # Override
     SchemaEditorClass = DatabaseSchemaEditor
+    features_class = DatabaseFeatures

--- a/django_multitenant/tests/test_models.py
+++ b/django_multitenant/tests/test_models.py
@@ -3,6 +3,7 @@ import re
 import django
 import pytest
 from django.conf import settings
+from django.db.models import Count
 from django.db.utils import NotSupportedError, DataError
 
 from django_multitenant.utils import (set_current_tenant,
@@ -718,3 +719,11 @@ class MultipleTenantModelTest(BaseTestCase):
         unset_current_tenant()
         project = Project.objects.filter(account=account).first()
         self.assertEqual(project.name, 'test update name')
+
+    def test_aggregate(self):
+        from .models import *
+        projects = self.projects
+        managers = self.project_managers
+        unset_current_tenant()
+        projects_per_manager = ProjectManager.objects.annotate(Count('project_id'))
+        list(projects_per_manager)

--- a/django_multitenant/tests/test_models.py
+++ b/django_multitenant/tests/test_models.py
@@ -721,7 +721,7 @@ class MultipleTenantModelTest(BaseTestCase):
         self.assertEqual(project.name, 'test update name')
 
     def test_aggregate(self):
-        from .models import *
+        from .models import ProjectManager
         projects = self.projects
         managers = self.project_managers
         unset_current_tenant()


### PR DESCRIPTION
As described in #63 and #64 there is an issue with the way django optimizes queries when aggregating that does not work for `TenantModel`s. This uses the fix and test originally contributed by @ledburyb in #64. However, it makes the test work on Python 3 and also changes it to use a better fix for Django 3.0+.

Closes #63 
Closes #64 