### PR TITLE
Bump Django version in test requirements

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 psycopg2
-Django<3
+Django>=3.2.9
 tox
 pytest
 pytest-cov


### PR DESCRIPTION
Dependabot was complaining that it could not detect the version of
Django that this project was using and that there were all kinds of CVEs
with old versions of Django. Hopefully this addresses that complaint
from dependabot.