### PR TITLE
Integrate automatic codeformatting using black

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *~
 .env/*
 django_multitenant.egg-info/
+.venv
+.tox/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+## Contributing
+
+This project welcomes contributions and suggestions. Most contributions
+require you to agree to a Contributor License Agreement (CLA) declaring that
+you have the right to, and actually do, grant us the rights to use your
+contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine
+whether you need to provide a CLA and decorate the PR appropriately (e.g.,
+label, comment). Simply follow the instructions provided by the bot. You
+will only need to do this once across all repositories using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of
+Conduct](https://opensource.microsoft.com/codeofconduct/). For more
+information see the [Code of Conduct
+FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
+questions or comments.
+
+### Following our coding conventions
+
+To format the python test files we use [black](https://github.com/psf/black).
+After installing like this you can run the following before committing:
+```bash
+make format
+```
+
+You can also run the following to automatically format all the files that you
+have changed before committing.
+
+```bash
+cat > .git/hooks/pre-commit << __EOF__
+#!/bin/bash
+black --check --quiet . || { black .; exit 1; }
+__EOF__
+chmod +x .git/hooks/pre-commit
+```
+
+### Running tests
+
+In one shell start a docker compose citus cluster:
+```bash
+docker-compose --project-name django-multitenant up
+```
+
+Then in another shell run the tests:
+
+```bash
+make test
+```

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ release-dependencies:
 	pip install -r requirements/release.txt
 
 
+format:
+	black .
+
+format-check:
+	black . --check
+
 release:
 	python -m build --sdist
 	twine check dist/*

--- a/django_multitenant/backends/postgresql/base.py
+++ b/django_multitenant/backends/postgresql/base.py
@@ -9,7 +9,7 @@ from django.db.backends.postgresql.base import (
     DatabaseFeatures,
     DatabaseOperations,
     DatabaseClient,
-    DatabaseIntrospection
+    DatabaseIntrospection,
 )
 from django_multitenant.fields import TenantForeignKey
 from django_multitenant.utils import get_model_by_db_table, get_tenant_column
@@ -26,13 +26,28 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
         return ret
 
     # Override
-    def _alter_field(self, model, old_field, new_field, old_type, new_type,
-                     old_db_params, new_db_params, strict=False):
+    def _alter_field(
+        self,
+        model,
+        old_field,
+        new_field,
+        old_type,
+        new_type,
+        old_db_params,
+        new_db_params,
+        strict=False,
+    ):
 
-        super(DatabaseSchemaEditor, self)._alter_field(model, old_field,
-                                                       new_field, old_type,
-                                                       new_type, old_db_params,
-                                                       new_db_params, strict)
+        super(DatabaseSchemaEditor, self)._alter_field(
+            model,
+            old_field,
+            new_field,
+            old_type,
+            new_type,
+            old_db_params,
+            new_db_params,
+            strict,
+        )
 
         # If the pkey was dropped in the previous distribute migration,
         # foreign key constraints didn't previously exists so django does not
@@ -40,16 +55,19 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
         # Here we test if we are in this case
         if isinstance(new_field, TenantForeignKey) and new_field.db_constraint:
             from_model = get_model_by_db_table(model._meta.db_table)
-            fk_names = (self._constraint_names(model,
-                                               [new_field.column],
-                                               foreign_key=True) +
-                        self._constraint_names(model,
-                                               [new_field.column,
-                                                get_tenant_column(from_model)],
-                                               foreign_key=True))
+            fk_names = self._constraint_names(
+                model, [new_field.column], foreign_key=True
+            ) + self._constraint_names(
+                model,
+                [new_field.column, get_tenant_column(from_model)],
+                foreign_key=True,
+            )
             if not fk_names:
-                self.execute(self._create_fk_sql(model, new_field,
-                                                 "_fk_%(to_table)s_%(to_column)s"))
+                self.execute(
+                    self._create_fk_sql(
+                        model, new_field, "_fk_%(to_table)s_%(to_column)s"
+                    )
+                )
 
     # Override
     def _create_fk_sql(self, model, field, suffix):
@@ -59,7 +77,9 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
                 # This case happens when we are running from scratch migrations and one model was removed from code
                 # In the previous migrations we would still be creating the foreign key
                 from_model = get_model_by_db_table(model._meta.db_table)
-                to_model = get_model_by_db_table(field.target_field.model._meta.db_table)
+                to_model = get_model_by_db_table(
+                    field.target_field.model._meta.db_table
+                )
             except ValueError:
                 return None
 
@@ -67,15 +87,21 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
             to_columns = field.target_field.column, get_tenant_column(to_model)
             suffix = suffix % {
                 "to_table": field.target_field.model._meta.db_table,
-                "to_column": '_'.join(to_columns),
+                "to_column": "_".join(to_columns),
             }
 
             return self.sql_create_fk % {
                 "table": self.quote_name(model._meta.db_table),
-                "name": self.quote_name(self._create_index_name(model, from_columns, suffix=suffix)),
-                "column": ', '.join([self.quote_name(from_col) for from_col in from_columns]),
+                "name": self.quote_name(
+                    self._create_index_name(model, from_columns, suffix=suffix)
+                ),
+                "column": ", ".join(
+                    [self.quote_name(from_col) for from_col in from_columns]
+                ),
                 "to_table": self.quote_name(field.target_field.model._meta.db_table),
-                "to_column": ', '.join([self.quote_name(to_col) for to_col in to_columns]),
+                "to_column": ", ".join(
+                    [self.quote_name(to_col) for to_col in to_columns]
+                ),
                 "deferrable": self.connection.ops.deferrable_sql(),
             }
         return super(DatabaseSchemaEditor, self)._create_fk_sql(model, field, suffix)
@@ -85,12 +111,11 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
         # Hack: Citus will throw the following error if these statements are
         # not executed separately: "ERROR: cannot execute multiple utility events"
         if sql and not params:
-            for statement in str(sql).split(';'):
+            for statement in str(sql).split(";"):
                 if statement and not statement.isspace():
                     super(DatabaseSchemaEditor, self).execute(statement)
         elif sql:
             super(DatabaseSchemaEditor, self).execute(sql, params)
-
 
     def _create_index_name(self, model, column_names, suffix=""):
         # compat with django 2.X and django 1.X
@@ -99,9 +124,10 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
         if not isinstance(model, str) and django.VERSION[0] > 1:
             model = model._meta.db_table
 
-        return super(DatabaseSchemaEditor, self)._create_index_name(model,
-                                                                    column_names,
-                                                                    suffix=suffix)
+        return super(DatabaseSchemaEditor, self)._create_index_name(
+            model, column_names, suffix=suffix
+        )
+
 
 class DatabaseFeatures(PostgresqlDatabaseFeatures):
     # The default Django behaviour is to collapse the fields to just the 'id'
@@ -110,14 +136,15 @@ class DatabaseFeatures(PostgresqlDatabaseFeatures):
     # for specific models that this behaviour should be disabled.
     def allows_group_by_selected_pks_on_model(self, model):
         from django_multitenant.models import TenantModel
+
         if issubclass(model, TenantModel):
             return False
         return super().allows_group_by_selected_pks_on_model(model)
+
     # For django versions before version 3.0 we set a flag that disables this
     # behaviour for all models.
     if django.VERSION[0] < 3:
         allows_group_by_selected_pks = False
-
 
 
 class DatabaseWrapper(PostgresqlDatabaseWrapper):

--- a/django_multitenant/deletion.py
+++ b/django_multitenant/deletion.py
@@ -4,7 +4,7 @@ from functools import reduce
 import django
 from django.db.models import Q
 
-from .utils import (get_current_tenant, get_tenant_filters)
+from .utils import get_current_tenant, get_tenant_filters
 
 
 def related_objects(obj, *args):
@@ -21,10 +21,13 @@ def related_objects(obj, *args):
         objs = args[2]
 
     filters = {}
-    predicate = reduce(operator.or_, (
-            Q(**{'%s__in' % related_field.name: objs})
+    predicate = reduce(
+        operator.or_,
+        (
+            Q(**{"%s__in" % related_field.name: objs})
             for related_field in related_fields
-        ))
+        ),
+    )
 
     if get_current_tenant():
         try:

--- a/django_multitenant/django_multitenant.py
+++ b/django_multitenant/django_multitenant.py
@@ -1,6 +1,7 @@
 import logging
 from django.apps import apps
 from django.db import models
+
 try:
     from threading import local
 except ImportError:
@@ -12,5 +13,4 @@ from collections import OrderedDict
 
 from .fields import TenantForeignKey, TenantOneToOneField
 from .models import TenantManager, TenantModel
-from .utils import (get_model_by_db_table,
-                    get_current_tenant, set_current_tenant)
+from .utils import get_model_by_db_table, get_current_tenant, set_current_tenant

--- a/django_multitenant/fields.py
+++ b/django_multitenant/fields.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class TenantForeignKey(models.ForeignKey):
-    '''
+    """
     Should be used in place of models.ForeignKey for all foreign key relationships to
     subclasses of TenantModel.
 
@@ -17,7 +17,7 @@ class TenantForeignKey(models.ForeignKey):
 
     Adds clause to forward accesses through this field to include tenant_id in the
     TenantModel lookup.
-    '''
+    """
 
     # Override
     def get_extra_descriptor_filter(self, instance):
@@ -38,12 +38,15 @@ class TenantForeignKey(models.ForeignKey):
         if current_tenant:
             return get_tenant_filters(self.related_model)
         else:
-            logger.warn('TenantForeignKey field %s.%s '
-                        'accessed without a current tenant set. '
-                        'This may cause issues in a partitioned environment. '
-                        'Recommend calling set_current_tenant() before accessing '
-                        'this field.',
-                        self.model.__name__, self.name)
+            logger.warn(
+                "TenantForeignKey field %s.%s "
+                "accessed without a current tenant set. "
+                "This may cause issues in a partitioned environment. "
+                "Recommend calling set_current_tenant() before accessing "
+                "this field.",
+                self.model.__name__,
+                self.name,
+            )
             return super(TenantForeignKey, self).get_extra_descriptor_filter(instance)
 
     # Override
@@ -78,14 +81,14 @@ class TenantForeignKey(models.ForeignKey):
         lookup_rhs = rhs_tenant_field.get_col(alias)
 
         # Create "AND lhs.tenant_id = rhs.tenant_id" as a new condition
-        lookup = lhs_tenant_field.get_lookup('exact')(lookup_lhs, lookup_rhs)
+        lookup = lhs_tenant_field.get_lookup("exact")(lookup_lhs, lookup_rhs)
         condition = where_class()
-        condition.add(lookup, 'AND')
+        condition.add(lookup, "AND")
         return condition
 
 
 class TenantOneToOneField(models.OneToOneField, TenantForeignKey):
     # Override
     def __init__(self, *args, **kwargs):
-        kwargs['unique'] = False
+        kwargs["unique"] = False
         super(TenantOneToOneField, self).__init__(*args, **kwargs)

--- a/django_multitenant/models.py
+++ b/django_multitenant/models.py
@@ -2,27 +2,25 @@ import logging
 
 from django.db import models
 
-from .mixins import (TenantManagerMixin,
-                     TenantModelMixin)
+from .mixins import TenantManagerMixin, TenantModelMixin
 
 from .utils import (
     set_current_tenant,
     get_current_tenant,
     get_model_by_db_table,
-    get_tenant_column
+    get_tenant_column,
 )
 
 logger = logging.getLogger(__name__)
 
 
-
 class TenantManager(TenantManagerMixin, models.Manager):
-    #Below is the manager related to the above class.
+    # Below is the manager related to the above class.
     pass
 
 
 class TenantModel(TenantModelMixin, models.Model):
-    #Abstract model which all the models related to tenant inherit.
+    # Abstract model which all the models related to tenant inherit.
 
     objects = TenantManager()
 

--- a/django_multitenant/query.py
+++ b/django_multitenant/query.py
@@ -1,13 +1,18 @@
 from django.db import connections, transaction
 from django.db.models import Q
 from django.db.models.sql.constants import (
-    GET_ITERATOR_CHUNK_SIZE, NO_RESULTS,
+    GET_ITERATOR_CHUNK_SIZE,
+    NO_RESULTS,
 )
 from django.conf import settings
 
 
-from .utils import (get_current_tenant, get_tenant_column,
-                    get_tenant_filters, is_distributed_model)
+from .utils import (
+    get_current_tenant,
+    get_tenant_column,
+    get_tenant_filters,
+    is_distributed_model,
+)
 
 
 def add_tenant_filters_on_query(obj):
@@ -16,9 +21,7 @@ def add_tenant_filters_on_query(obj):
     if current_tenant:
         try:
             filters = get_tenant_filters(obj.model)
-            obj.add_q(Q(
-                **filters
-            ))
+            obj.add_q(Q(**filters))
         except ValueError:
             pass
 
@@ -37,7 +40,7 @@ def wrap_update_batch(base_update_batch):
         obj.add_update_values(values)
         for offset in range(0, len(pk_list), GET_ITERATOR_CHUNK_SIZE):
             obj.where = obj.where_class()
-            obj.add_q(Q(pk__in=pk_list[offset: offset + GET_ITERATOR_CHUNK_SIZE]))
+            obj.add_q(Q(pk__in=pk_list[offset : offset + GET_ITERATOR_CHUNK_SIZE]))
             add_tenant_filters_on_query(obj)
             obj.get_compiler(using).execute_sql(NO_RESULTS)
 
@@ -45,10 +48,11 @@ def wrap_update_batch(base_update_batch):
     return update_batch
 
 
-
 def wrap_delete(base_delete):
     def delete(obj):
-        obj_are_distributed = [is_distributed_model(instance) for instance in obj.data.keys()]
+        obj_are_distributed = [
+            is_distributed_model(instance) for instance in obj.data.keys()
+        ]
 
         # If all elements are from distributed tables, then we can do a simple atomic transaction.
         # If there are mixes of distributed and reference tables, it would raise the following error :
@@ -57,13 +61,18 @@ def wrap_delete(base_delete):
         # "table" because there was a parallel DML access to distributed relation
         # "table2" in the same transaction
 
-        if (len(set(obj_are_distributed)) > 1
-            and getattr(settings, 'CITUS_EXTENSION_INSTALLED', False)):
+        if len(set(obj_are_distributed)) > 1 and getattr(
+            settings, "CITUS_EXTENSION_INSTALLED", False
+        ):
             # all elements are not the same, some False, some True
             with transaction.atomic(using=obj.using, savepoint=False):
-                connections[obj.using].cursor().execute("SET LOCAL citus.multi_shard_modify_mode TO 'sequential';")
+                connections[obj.using].cursor().execute(
+                    "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
+                )
                 result = base_delete(obj)
-                connections[obj.using].cursor().execute("SET LOCAL citus.multi_shard_modify_mode TO 'parallel';")
+                connections[obj.using].cursor().execute(
+                    "SET LOCAL citus.multi_shard_modify_mode TO 'parallel';"
+                )
                 return result
 
         return base_delete(obj)

--- a/django_multitenant/settings.py
+++ b/django_multitenant/settings.py
@@ -2,6 +2,6 @@ from django.conf import settings
 
 APP_NAMESPACE = "DJANGO_MULTITENANT"
 
-TENANT_COOKIE_NAME = getattr(settings, 'TENANT_COOKIE_NAME', 'tenant_id')
-TENANT_MODEL_NAME = getattr(settings, 'TENANT_MODEL_NAME', None)
-CITUS_EXTENSION_INSTALLED = getattr(settings, 'CITUS_EXTENSION_INSTALLED', False)
+TENANT_COOKIE_NAME = getattr(settings, "TENANT_COOKIE_NAME", "tenant_id")
+TENANT_MODEL_NAME = getattr(settings, "TENANT_MODEL_NAME", None)
+CITUS_EXTENSION_INSTALLED = getattr(settings, "CITUS_EXTENSION_INSTALLED", False)

--- a/django_multitenant/tests/base.py
+++ b/django_multitenant/tests/base.py
@@ -15,45 +15,49 @@ class Fixtures(Exam):
 
     @fixture
     def india(self):
-        return Country.objects.create(name='India')
+        return Country.objects.create(name="India")
 
     @fixture
     def france(self):
-        return Country.objects.create(name='France')
+        return Country.objects.create(name="France")
 
     @fixture
     def united_states(self):
-        return Country.objects.create(name='United States')
+        return Country.objects.create(name="United States")
 
     @fixture
     def account_fr(self):
-        return Account.objects.create(pk=1,
-                                      name='Account FR',
-                                      country=self.france,
-                                      subdomain='fr.',
-                                      domain='citusdata.com')
+        return Account.objects.create(
+            pk=1,
+            name="Account FR",
+            country=self.france,
+            subdomain="fr.",
+            domain="citusdata.com",
+        )
 
     @fixture
     def account_in(self):
-        return Account.objects.create(pk=2,
-                                      name='Account IN',
-                                      country=self.india,
-                                      subdomain='in.',
-                                      domain='citusdata.com')
+        return Account.objects.create(
+            pk=2,
+            name="Account IN",
+            country=self.india,
+            subdomain="in.",
+            domain="citusdata.com",
+        )
 
     @fixture
     def account_us(self):
-        return Account.objects.create(pk=3,
-                                      name='Account US',
-                                      country=self.united_states,
-                                      subdomain='us.',
-                                      domain='citusdata.com')
-
+        return Account.objects.create(
+            pk=3,
+            name="Account US",
+            country=self.united_states,
+            subdomain="us.",
+            domain="citusdata.com",
+        )
 
     @fixture
     def accounts(self):
         return [self.account_fr, self.account_in, self.account_us]
-
 
     @fixture
     def projects(self):
@@ -62,12 +66,10 @@ class Fixtures(Exam):
         for account in self.accounts:
             for i in range(10):
                 projects.append(
-                    Project.objects.create(account_id=account.pk,
-                                           name='project %d' % i)
+                    Project.objects.create(account_id=account.pk, name="project %d" % i)
                 )
 
         return projects
-
 
     @fixture
     def managers(self):
@@ -76,8 +78,7 @@ class Fixtures(Exam):
         for account in self.accounts:
             for i in range(5):
                 managers.append(
-                    Manager.objects.create(name='manager %d' % i,
-                                           account=account)
+                    Manager.objects.create(name="manager %d" % i, account=account)
                 )
 
         return managers
@@ -90,10 +91,11 @@ class Fixtures(Exam):
             previous_task = None
             for i in range(5):
                 previous_task = Task.objects.create(
-                    name='task project %s %i' %(project.name, i),
+                    name="task project %s %i" % (project.name, i),
                     project_id=project.pk,
                     account_id=project.account_id,
-                    parent=previous_task)
+                    parent=previous_task,
+                )
 
                 tasks.append(previous_task)
 
@@ -123,9 +125,10 @@ class Fixtures(Exam):
         for project in projects:
             for manager in project.account.managers.all():
                 project_managers.append(
-                    ProjectManager.objects.create(account=project.account,
-                                                  project=project,
-                                                  manager=manager))
+                    ProjectManager.objects.create(
+                        account=project.account, project=project, manager=manager
+                    )
+                )
         return project_managers
 
     @fixture
@@ -136,11 +139,12 @@ class Fixtures(Exam):
             for i in range(5):
                 subtasks.append(
                     SubTask.objects.create(
-                        name='subtask project %i, task %i',
-                        type='test',
+                        name="subtask project %i, task %i",
+                        type="test",
                         account_id=task.account_id,
                         project_id=task.project_id,
-                        task=task)
+                        task=task,
+                    )
                 )
 
         return subtasks
@@ -155,21 +159,21 @@ class Fixtures(Exam):
 
     @fixture
     def organization(self):
-        return Organization.objects.create(name='organization')
+        return Organization.objects.create(name="organization")
 
     @fixture
     def tenant_not_id(self):
         tenants = []
         for i in range(3):
-            tenant = TenantNotIdModel(tenant_column=i+1,
-                                      name='test %d' % i)
+            tenant = TenantNotIdModel(tenant_column=i + 1, name="test %d" % i)
             tenant.save()
 
             tenants.append(tenant)
 
             for j in range(10):
-                SomeRelatedModel.objects.create(related_tenant=tenant,
-                                                name='related %d' % j)
+                SomeRelatedModel.objects.create(
+                    related_tenant=tenant, name="related %d" % j
+                )
         return tenants
 
 

--- a/django_multitenant/tests/migrations/0001_initial.py
+++ b/django_multitenant/tests/migrations/0001_initial.py
@@ -12,169 +12,331 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='Account',
+            name="Account",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
-                ('domain', models.CharField(max_length=255)),
-                ('subdomain', models.CharField(max_length=255)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                ("domain", models.CharField(max_length=255)),
+                ("subdomain", models.CharField(max_length=255)),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='AliasedTask',
+            name="AliasedTask",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('account', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Account')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "account",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to="tests.Account"
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='Country',
+            name="Country",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
             ],
         ),
         migrations.CreateModel(
-            name='Manager',
+            name="Manager",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
-                ('account', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Account')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                (
+                    "account",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to="tests.Account"
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='Organization',
+            name="Organization",
             fields=[
-                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
-                ('name', models.CharField(max_length=255)),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='Project',
+            name="Project",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
-                ('account', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='account', to='tests.Account')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                (
+                    "account",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="account",
+                        to="tests.Account",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='ProjectManager',
+            name="ProjectManager",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('account', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Account')),
-                ('manager', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Manager')),
-                ('project', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Project')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "account",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to="tests.Account"
+                    ),
+                ),
+                (
+                    "manager",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to="tests.Manager"
+                    ),
+                ),
+                (
+                    "project",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to="tests.Project"
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='Record',
+            name="Record",
             fields=[
-                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
-                ('name', models.CharField(max_length=255)),
-                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Organization')),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                (
+                    "organization",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="tests.Organization",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='SubTask',
+            name="SubTask",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
-                ('type', models.CharField(max_length=255)),
-                ('account', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Account')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                ("type", models.CharField(max_length=255)),
+                (
+                    "account",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to="tests.Account"
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='Task',
+            name="Task",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
-                ('account', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Account')),
-                ('project', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='tasks', to='tests.Project')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                (
+                    "account",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to="tests.Account"
+                    ),
+                ),
+                (
+                    "project",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="tasks",
+                        to="tests.Project",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='UnscopedModel',
+            name="UnscopedModel",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
             ],
         ),
         migrations.CreateModel(
-            name='SomeRelatedModel',
+            name="SomeRelatedModel",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='TenantNotIdModel',
+            name="TenantNotIdModel",
             fields=[
-                ('tenant_column', models.IntegerField(primary_key=True, serialize=False)),
-                ('name', models.CharField(max_length=255)),
+                (
+                    "tenant_column",
+                    models.IntegerField(primary_key=True, serialize=False),
+                ),
+                ("name", models.CharField(max_length=255)),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.AddField(
-            model_name='somerelatedmodel',
-            name='related_tenant',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.TenantNotIdModel'),
-        ),
-
-        migrations.AddField(
-            model_name='subtask',
-            name='task',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Task'),
+            model_name="somerelatedmodel",
+            name="related_tenant",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to="tests.TenantNotIdModel"
+            ),
         ),
         migrations.AddField(
-            model_name='project',
-            name='managers',
-            field=models.ManyToManyField(through='tests.ProjectManager', to='tests.Manager'),
+            model_name="subtask",
+            name="task",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to="tests.Task"
+            ),
         ),
         migrations.AddField(
-            model_name='aliasedtask',
-            name='project_alias',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Project'),
+            model_name="project",
+            name="managers",
+            field=models.ManyToManyField(
+                through="tests.ProjectManager", to="tests.Manager"
+            ),
         ),
         migrations.AddField(
-            model_name='account',
-            name='country',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Country'),
+            model_name="aliasedtask",
+            name="project_alias",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to="tests.Project"
+            ),
+        ),
+        migrations.AddField(
+            model_name="account",
+            name="country",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to="tests.Country"
+            ),
         ),
     ]

--- a/django_multitenant/tests/migrations/0002_distribute.py
+++ b/django_multitenant/tests/migrations/0002_distribute.py
@@ -7,57 +7,93 @@ from django.conf import settings
 
 from django_multitenant.db import migrations as tenant_migrations
 
+
 def get_operations():
     operations = []
     if settings.USE_CITUS:
         operations = [
             # necessary for tests
             migrations.RunSQL("CREATE EXTENSION IF NOT EXISTS citus;"),
-            migrations.RunSQL("SELECT * from master_add_node('django-multitenant_worker1_1', 5432);"),
-            migrations.RunSQL("SELECT * from master_add_node('django-multitenant_worker2_1', 5432);")]
-
+            migrations.RunSQL(
+                "SELECT * from master_add_node('django-multitenant_worker1_1', 5432);"
+            ),
+            migrations.RunSQL(
+                "SELECT * from master_add_node('django-multitenant_worker2_1', 5432);"
+            ),
+        ]
 
     operations += [
         # Drop constraints
-        migrations.RunSQL("""
+        migrations.RunSQL(
+            """
         ALTER TABLE tests_aliasedtask
         DROP CONSTRAINT tests_aliasedtask_pkey CASCADE;
 
         ALTER TABLE tests_aliasedtask ADD CONSTRAINT
         tests_aliasedtask_pkey PRIMARY KEY (account_id, id);
-        """),
-        migrations.RunSQL("ALTER TABLE tests_country DROP CONSTRAINT tests_country_pkey CASCADE;"),
-        migrations.RunSQL("ALTER TABLE tests_manager DROP CONSTRAINT tests_manager_pkey CASCADE;"),
-        migrations.RunSQL("ALTER TABLE tests_project DROP CONSTRAINT tests_project_pkey CASCADE;"),
-        migrations.RunSQL("ALTER TABLE tests_projectmanager DROP CONSTRAINT tests_projectmanager_pkey CASCADE;"),
-        migrations.RunSQL("ALTER TABLE tests_record DROP CONSTRAINT tests_record_pkey CASCADE;"),
-        migrations.RunSQL("ALTER TABLE tests_subtask DROP CONSTRAINT tests_subtask_pkey CASCADE;"),
-        migrations.RunSQL("ALTER TABLE tests_task DROP CONSTRAINT tests_task_pkey CASCADE;"),
+        """
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_country DROP CONSTRAINT tests_country_pkey CASCADE;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_manager DROP CONSTRAINT tests_manager_pkey CASCADE;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_project DROP CONSTRAINT tests_project_pkey CASCADE;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_projectmanager DROP CONSTRAINT tests_projectmanager_pkey CASCADE;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_record DROP CONSTRAINT tests_record_pkey CASCADE;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_subtask DROP CONSTRAINT tests_subtask_pkey CASCADE;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_task DROP CONSTRAINT tests_task_pkey CASCADE;"
+        ),
     ]
 
     if settings.USE_CITUS:
         # distribute
         operations += [
-            tenant_migrations.Distribute('Country', reference=True),
-            tenant_migrations.Distribute('Account'),
-            tenant_migrations.Distribute('AliasedTask'),
-            tenant_migrations.Distribute('Manager'),
-            tenant_migrations.Distribute('Organization'),
-            tenant_migrations.Distribute('Project'),
-            tenant_migrations.Distribute('ProjectManager'),
-            tenant_migrations.Distribute('Record'),
-            tenant_migrations.Distribute('SubTask'),
-            tenant_migrations.Distribute('Task')]
+            tenant_migrations.Distribute("Country", reference=True),
+            tenant_migrations.Distribute("Account"),
+            tenant_migrations.Distribute("AliasedTask"),
+            tenant_migrations.Distribute("Manager"),
+            tenant_migrations.Distribute("Organization"),
+            tenant_migrations.Distribute("Project"),
+            tenant_migrations.Distribute("ProjectManager"),
+            tenant_migrations.Distribute("Record"),
+            tenant_migrations.Distribute("SubTask"),
+            tenant_migrations.Distribute("Task"),
+        ]
 
     # Add constraints
     operations += [
-        migrations.RunSQL("ALTER TABLE tests_country ADD CONSTRAINT tests_country_pkey PRIMARY KEY (id);"),
-        migrations.RunSQL("ALTER TABLE tests_project ADD CONSTRAINT tests_project_pkey PRIMARY KEY (account_id, id);"),
-        migrations.RunSQL("ALTER TABLE tests_manager ADD CONSTRAINT tests_manager_pkey PRIMARY KEY (account_id, id);"),
-        migrations.RunSQL("ALTER TABLE tests_projectmanager ADD CONSTRAINT tests_projectmanager_pkey PRIMARY KEY (account_id, id);"),
-        migrations.RunSQL("ALTER TABLE tests_record ADD CONSTRAINT tests_record_pkey PRIMARY KEY (organization_id, id);"),
-        migrations.RunSQL("ALTER TABLE tests_subtask ADD CONSTRAINT tests_subtask_pkey PRIMARY KEY (account_id, id);"),
-        migrations.RunSQL("ALTER TABLE tests_task ADD CONSTRAINT tests_task_pkey PRIMARY KEY (account_id, id);")
+        migrations.RunSQL(
+            "ALTER TABLE tests_country ADD CONSTRAINT tests_country_pkey PRIMARY KEY (id);"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_project ADD CONSTRAINT tests_project_pkey PRIMARY KEY (account_id, id);"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_manager ADD CONSTRAINT tests_manager_pkey PRIMARY KEY (account_id, id);"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_projectmanager ADD CONSTRAINT tests_projectmanager_pkey PRIMARY KEY (account_id, id);"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_record ADD CONSTRAINT tests_record_pkey PRIMARY KEY (organization_id, id);"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_subtask ADD CONSTRAINT tests_subtask_pkey PRIMARY KEY (account_id, id);"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_task ADD CONSTRAINT tests_task_pkey PRIMARY KEY (account_id, id);"
+        ),
     ]
 
     return operations
@@ -67,7 +103,7 @@ class Migration(migrations.Migration):
     atomic = False
 
     dependencies = [
-        ('tests', '0001_initial'),
+        ("tests", "0001_initial"),
     ]
 
     operations = get_operations()

--- a/django_multitenant/tests/migrations/0003_auto_20181220_1151.py
+++ b/django_multitenant/tests/migrations/0003_auto_20181220_1151.py
@@ -11,21 +11,31 @@ from django_multitenant.db import migrations as tenant_migrations
 
 def get_operations():
     operations = [
-        migrations.RunSQL("ALTER TABLE tests_tenantnotidmodel DROP CONSTRAINT tests_tenantnotidmodel_pkey CASCADE;", reverse_sql='ALTER TABLE tests_tenantnotidmodel ADD CONSTRAINT tests_tenantnotidmodel_pkey PRIMARY KEY (tenant_column);'),
-        migrations.RunSQL("ALTER TABLE tests_somerelatedmodel DROP CONSTRAINT tests_somerelatedmodel_pkey CASCADE;", reverse_sql='ALTER TABLE tests_somerelatedmodel ADD CONSTRAINT tests_somerelatedmodel_pkey PRIMARY KEY (related_tenant_id, id);'),
+        migrations.RunSQL(
+            "ALTER TABLE tests_tenantnotidmodel DROP CONSTRAINT tests_tenantnotidmodel_pkey CASCADE;",
+            reverse_sql="ALTER TABLE tests_tenantnotidmodel ADD CONSTRAINT tests_tenantnotidmodel_pkey PRIMARY KEY (tenant_column);",
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_somerelatedmodel DROP CONSTRAINT tests_somerelatedmodel_pkey CASCADE;",
+            reverse_sql="ALTER TABLE tests_somerelatedmodel ADD CONSTRAINT tests_somerelatedmodel_pkey PRIMARY KEY (related_tenant_id, id);",
+        ),
     ]
 
     if settings.USE_CITUS:
         operations += [
-            tenant_migrations.Distribute('TenantNotIdModel'),
-            tenant_migrations.Distribute('SomeRelatedModel'),
+            tenant_migrations.Distribute("TenantNotIdModel"),
+            tenant_migrations.Distribute("SomeRelatedModel"),
         ]
 
     operations += [
-        migrations.RunSQL("ALTER TABLE tests_somerelatedmodel ADD CONSTRAINT tests_somerelatedmodel_pkey PRIMARY KEY (related_tenant_id, id);", 
-            reverse_sql='ALTER TABLE tests_somerelatedmodel DROP CONSTRAINT tests_somerelatedmodel_pkey CASCADE;'),
-        migrations.RunSQL("ALTER TABLE tests_tenantnotidmodel ADD CONSTRAINT tests_tenantnotidmodel_pkey PRIMARY KEY (tenant_column);", 
-            reverse_sql='ALTER TABLE tests_tenantnotidmodel DROP CONSTRAINT tests_tenantnotidmodel_pkey CASCADE;')
+        migrations.RunSQL(
+            "ALTER TABLE tests_somerelatedmodel ADD CONSTRAINT tests_somerelatedmodel_pkey PRIMARY KEY (related_tenant_id, id);",
+            reverse_sql="ALTER TABLE tests_somerelatedmodel DROP CONSTRAINT tests_somerelatedmodel_pkey CASCADE;",
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_tenantnotidmodel ADD CONSTRAINT tests_tenantnotidmodel_pkey PRIMARY KEY (tenant_column);",
+            reverse_sql="ALTER TABLE tests_tenantnotidmodel DROP CONSTRAINT tests_tenantnotidmodel_pkey CASCADE;",
+        ),
     ]
 
     return operations
@@ -34,7 +44,7 @@ def get_operations():
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0002_distribute'),
+        ("tests", "0002_distribute"),
     ]
 
     operations = get_operations()

--- a/django_multitenant/tests/migrations/0004_auto_20190301_0834.py
+++ b/django_multitenant/tests/migrations/0004_auto_20190301_0834.py
@@ -7,18 +7,26 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0003_auto_20181220_1151'),
+        ("tests", "0003_auto_20181220_1151"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='manager',
-            name='account',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='managers', to='tests.Account'),
+            model_name="manager",
+            name="account",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="managers",
+                to="tests.Account",
+            ),
         ),
         migrations.AlterField(
-            model_name='project',
-            name='account',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='projects', to='tests.Account'),
+            model_name="project",
+            name="account",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="projects",
+                to="tests.Account",
+            ),
         ),
     ]

--- a/django_multitenant/tests/migrations/0005_auto_20190301_0842.py
+++ b/django_multitenant/tests/migrations/0005_auto_20190301_0842.py
@@ -6,13 +6,15 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0004_auto_20190301_0834'),
+        ("tests", "0004_auto_20190301_0834"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='tenantnotidmodel',
-            name='tenant_column',
-            field=models.IntegerField(editable=False, primary_key=True, serialize=False),
+            model_name="tenantnotidmodel",
+            name="tenant_column",
+            field=models.IntegerField(
+                editable=False, primary_key=True, serialize=False
+            ),
         ),
     ]

--- a/django_multitenant/tests/migrations/0006_subtask_project.py
+++ b/django_multitenant/tests/migrations/0006_subtask_project.py
@@ -8,13 +8,17 @@ import django_multitenant.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0005_auto_20190301_0842'),
+        ("tests", "0005_auto_20190301_0842"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='subtask',
-            name='project',
-            field=django_multitenant.fields.TenantForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, to='tests.Project'),
+            model_name="subtask",
+            name="project",
+            field=django_multitenant.fields.TenantForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="tests.Project",
+            ),
         ),
     ]

--- a/django_multitenant/tests/migrations/0007_alter_foreignkey_field.py
+++ b/django_multitenant/tests/migrations/0007_alter_foreignkey_field.py
@@ -8,13 +8,15 @@ import django_multitenant.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0006_subtask_project'),
+        ("tests", "0006_subtask_project"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='task',
-            name='project',
-            field=django_multitenant.fields.TenantForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Project'),
+            model_name="task",
+            name="project",
+            field=django_multitenant.fields.TenantForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to="tests.Project"
+            ),
         ),
     ]

--- a/django_multitenant/tests/migrations/0008_auto_20190412_0831.py
+++ b/django_multitenant/tests/migrations/0008_auto_20190412_0831.py
@@ -11,13 +11,13 @@ import django_multitenant.mixins
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0007_alter_foreignkey_field'),
+        ("tests", "0007_alter_foreignkey_field"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='somerelatedmodel',
-            name='opened',
+            model_name="somerelatedmodel",
+            name="opened",
             field=models.BooleanField(default=True),
         ),
     ]

--- a/django_multitenant/tests/migrations/0009_auto_20190412_0839.py
+++ b/django_multitenant/tests/migrations/0009_auto_20190412_0839.py
@@ -10,17 +10,17 @@ import django_multitenant.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0008_auto_20190412_0831'),
+        ("tests", "0008_auto_20190412_0831"),
     ]
 
     operations = [
         migrations.RemoveField(
-            model_name='somerelatedmodel',
-            name='opened',
+            model_name="somerelatedmodel",
+            name="opened",
         ),
         migrations.AddField(
-            model_name='task',
-            name='opened',
+            model_name="task",
+            name="opened",
             field=models.BooleanField(default=True),
         ),
     ]

--- a/django_multitenant/tests/migrations/0010_auto_20190517_1514.py
+++ b/django_multitenant/tests/migrations/0010_auto_20190517_1514.py
@@ -11,22 +11,35 @@ import django_multitenant.mixins
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0009_auto_20190412_0839'),
+        ("tests", "0009_auto_20190412_0839"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='TempModel',
+            name="TempModel",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
-                ('account', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Account', db_constraint=False)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                (
+                    "account",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="tests.Account",
+                        db_constraint=False,
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
             bases=(django_multitenant.mixins.TenantModelMixin, models.Model),
         ),
-
-
     ]

--- a/django_multitenant/tests/migrations/0011_distribute_new_table.py
+++ b/django_multitenant/tests/migrations/0011_distribute_new_table.py
@@ -13,12 +13,19 @@ from django_multitenant.db import migrations as tenant_migrations
 
 def get_operations():
     operations = [
-        migrations.RunSQL("ALTER TABLE tests_tempmodel DROP CONSTRAINT tests_tempmodel_pkey CASCADE;", reverse_sql=''),
-        migrations.RunSQL("ALTER TABLE tests_tempmodel ADD CONSTRAINT tests_tempmodel_pkey PRIMARY KEY (account_id, id);", reverse_sql='')]
+        migrations.RunSQL(
+            "ALTER TABLE tests_tempmodel DROP CONSTRAINT tests_tempmodel_pkey CASCADE;",
+            reverse_sql="",
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_tempmodel ADD CONSTRAINT tests_tempmodel_pkey PRIMARY KEY (account_id, id);",
+            reverse_sql="",
+        ),
+    ]
 
     if settings.USE_CITUS:
         operations += [
-            tenant_migrations.Distribute('TempModel', reverse_ignore=True),
+            tenant_migrations.Distribute("TempModel", reverse_ignore=True),
         ]
 
     return operations
@@ -27,6 +34,6 @@ def get_operations():
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0010_auto_20190517_1514'),
+        ("tests", "0010_auto_20190517_1514"),
     ]
     operations = get_operations()

--- a/django_multitenant/tests/migrations/0012_auto_20190517_1606.py
+++ b/django_multitenant/tests/migrations/0012_auto_20190517_1606.py
@@ -10,24 +10,33 @@ import django_multitenant.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0011_distribute_new_table'),
+        ("tests", "0011_distribute_new_table"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='projectmanager',
-            name='project',
-            field=django_multitenant.fields.TenantForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Project'),
+            model_name="projectmanager",
+            name="project",
+            field=django_multitenant.fields.TenantForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to="tests.Project"
+            ),
         ),
-
         migrations.AddField(
-            model_name='tempmodel',
-            name='project',
-            field=django_multitenant.fields.TenantForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, to='tests.Project'),
+            model_name="tempmodel",
+            name="project",
+            field=django_multitenant.fields.TenantForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="tests.Project",
+            ),
         ),
         migrations.AlterField(
-            model_name='tempmodel',
-            name='account',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tests.Account', db_constraint=False),
+            model_name="tempmodel",
+            name="account",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                to="tests.Account",
+                db_constraint=False,
+            ),
         ),
     ]

--- a/django_multitenant/tests/migrations/0013_auto_20190517_1607.py
+++ b/django_multitenant/tests/migrations/0013_auto_20190517_1607.py
@@ -10,15 +10,15 @@ import django_multitenant.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0012_auto_20190517_1606'),
+        ("tests", "0012_auto_20190517_1606"),
     ]
 
     operations = [
         migrations.RemoveField(
-            model_name='tempmodel',
-            name='project',
+            model_name="tempmodel",
+            name="project",
         ),
         migrations.DeleteModel(
-            name='TempModel',
+            name="TempModel",
         ),
     ]

--- a/django_multitenant/tests/migrations/0014_auto_20190828_1314.py
+++ b/django_multitenant/tests/migrations/0014_auto_20190828_1314.py
@@ -11,18 +11,26 @@ import django_multitenant.mixins
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0013_auto_20190517_1607'),
+        ("tests", "0013_auto_20190517_1607"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='MigrationTestModel',
+            name="MigrationTestModel",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
             bases=(django_multitenant.mixins.TenantModelMixin, models.Model),
         ),

--- a/django_multitenant/tests/migrations/0015_auto_20190829_1334.py
+++ b/django_multitenant/tests/migrations/0015_auto_20190829_1334.py
@@ -10,15 +10,23 @@ import django_multitenant.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0014_auto_20190828_1314'),
+        ("tests", "0014_auto_20190828_1314"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='MigrationTestReferenceModel',
+            name="MigrationTestReferenceModel",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
             ],
         ),
     ]

--- a/django_multitenant/tests/migrations/0016_auto_20191025_0844.py
+++ b/django_multitenant/tests/migrations/0016_auto_20191025_0844.py
@@ -10,13 +10,17 @@ import django_multitenant.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0015_auto_20190829_1334'),
+        ("tests", "0015_auto_20190829_1334"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='projectmanager',
-            name='project',
-            field=django_multitenant.fields.TenantForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='projectmanagers', to='tests.Project'),
+            model_name="projectmanager",
+            name="project",
+            field=django_multitenant.fields.TenantForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="projectmanagers",
+                to="tests.Project",
+            ),
         ),
     ]

--- a/django_multitenant/tests/migrations/0017_auto_20200128_0853.py
+++ b/django_multitenant/tests/migrations/0017_auto_20200128_0853.py
@@ -11,25 +11,57 @@ from django_multitenant.db import migrations as tenant_migrations
 def get_operations():
     operations = [
         migrations.CreateModel(
-            name='Employee',
+            name="Employee",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
-                ('account', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='employees', db_constraint=False, to='tests.Account')),
-                ('created_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='users_created', to='tests.Employee')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                (
+                    "account",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="employees",
+                        db_constraint=False,
+                        to="tests.Account",
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="users_created",
+                        to="tests.Employee",
+                    ),
+                ),
             ],
         ),
     ]
 
     if settings.USE_CITUS:
-        operations += [tenant_migrations.Distribute('Employee', reference=True, reverse_ignore=True),]
+        operations += [
+            tenant_migrations.Distribute(
+                "Employee", reference=True, reverse_ignore=True
+            ),
+        ]
 
     return operations
+
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0016_auto_20191025_0844'),
+        ("tests", "0016_auto_20191025_0844"),
     ]
 
     operations = get_operations()

--- a/django_multitenant/tests/migrations/0017_auto_20200204_0929.py
+++ b/django_multitenant/tests/migrations/0017_auto_20200204_0929.py
@@ -8,13 +8,19 @@ import django_multitenant.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0016_auto_20191025_0844'),
+        ("tests", "0016_auto_20191025_0844"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='task',
-            name='parent',
-            field=django_multitenant.fields.TenantForeignKey(blank=True, db_index=False, null=True, on_delete=django.db.models.deletion.CASCADE, to='tests.Task'),
+            model_name="task",
+            name="parent",
+            field=django_multitenant.fields.TenantForeignKey(
+                blank=True,
+                db_index=False,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="tests.Task",
+            ),
         ),
     ]

--- a/django_multitenant/tests/migrations/0018_auto_20200128_0902.py
+++ b/django_multitenant/tests/migrations/0018_auto_20200128_0902.py
@@ -12,25 +12,54 @@ from django_multitenant.db import migrations as tenant_migrations
 def get_operations():
     operations = [
         migrations.CreateModel(
-            name='ModelConfig',
+            name="ModelConfig",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
-                ('account', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='configs', to='tests.Account')),
-                ('employee', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='configs', to='tests.Employee')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                (
+                    "account",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="configs",
+                        to="tests.Account",
+                    ),
+                ),
+                (
+                    "employee",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="configs",
+                        to="tests.Employee",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
             bases=(django_multitenant.mixins.TenantModelMixin, models.Model),
         ),
-
-        migrations.RunSQL("ALTER TABLE tests_modelconfig DROP CONSTRAINT tests_modelconfig_pkey CASCADE;", reverse_sql=''),
-        migrations.RunSQL("ALTER TABLE tests_modelconfig ADD CONSTRAINT tests_modelconfig_pkey PRIMARY KEY (account_id, id);", reverse_sql=''),
+        migrations.RunSQL(
+            "ALTER TABLE tests_modelconfig DROP CONSTRAINT tests_modelconfig_pkey CASCADE;",
+            reverse_sql="",
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE tests_modelconfig ADD CONSTRAINT tests_modelconfig_pkey PRIMARY KEY (account_id, id);",
+            reverse_sql="",
+        ),
     ]
 
     if settings.USE_CITUS:
-        operations += [tenant_migrations.Distribute('ModelConfig', reverse_ignore=True),]
+        operations += [
+            tenant_migrations.Distribute("ModelConfig", reverse_ignore=True),
+        ]
 
     return operations
 
@@ -40,7 +69,7 @@ class Migration(migrations.Migration):
     atomic = False
 
     dependencies = [
-        ('tests', '0017_auto_20200128_0853'),
+        ("tests", "0017_auto_20200128_0853"),
     ]
 
     operations = get_operations()

--- a/django_multitenant/tests/migrations/0019_auto_20200129_0357.py
+++ b/django_multitenant/tests/migrations/0019_auto_20200129_0357.py
@@ -8,14 +8,20 @@ import django_multitenant.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0018_auto_20200128_0902'),
+        ("tests", "0018_auto_20200128_0902"),
     ]
 
     atomic = False
     operations = [
         migrations.AddField(
-            model_name='account',
-            name='employee',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='accounts', to='tests.Employee'),
+            model_name="account",
+            name="employee",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="accounts",
+                to="tests.Employee",
+            ),
         ),
     ]

--- a/django_multitenant/tests/migrations/0020_auto_20200129_0404.py
+++ b/django_multitenant/tests/migrations/0020_auto_20200129_0404.py
@@ -8,15 +8,21 @@ import django_multitenant.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0019_auto_20200129_0357'),
+        ("tests", "0019_auto_20200129_0357"),
     ]
 
     atomic = False
 
     operations = [
         migrations.AddField(
-            model_name='project',
-            name='employee',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='projects', to='tests.Employee'),
+            model_name="project",
+            name="employee",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="projects",
+                to="tests.Employee",
+            ),
         ),
     ]

--- a/django_multitenant/tests/migrations/0021_auto_20200129_0453.py
+++ b/django_multitenant/tests/migrations/0021_auto_20200129_0453.py
@@ -8,13 +8,19 @@ import django_multitenant.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0020_auto_20200129_0404'),
+        ("tests", "0020_auto_20200129_0404"),
     ]
     atomic = False
     operations = [
         migrations.AlterField(
-            model_name='modelconfig',
-            name='employee',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='configs', to='tests.Employee'),
+            model_name="modelconfig",
+            name="employee",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="configs",
+                to="tests.Employee",
+            ),
         )
     ]

--- a/django_multitenant/tests/migrations/0022_merge_20200211_1000.py
+++ b/django_multitenant/tests/migrations/0022_merge_20200211_1000.py
@@ -6,9 +6,8 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0017_auto_20200204_0929'),
-        ('tests', '0021_auto_20200129_0453'),
+        ("tests", "0017_auto_20200204_0929"),
+        ("tests", "0021_auto_20200129_0453"),
     ]
 
-    operations = [
-    ]
+    operations = []

--- a/django_multitenant/tests/migrations/0023_auto_20200412_0603.py
+++ b/django_multitenant/tests/migrations/0023_auto_20200412_0603.py
@@ -13,24 +13,52 @@ from django_multitenant.db import migrations as tenant_migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tests', '0022_merge_20200211_1000'),
+        ("tests", "0022_merge_20200211_1000"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='Revenue',
+            name="Revenue",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('value', models.CharField(max_length=30)),
-                ('acc', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='revenues', to='tests.Account')),
-                ('project', django_multitenant.fields.TenantForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='revenues', to='tests.Project')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("value", models.CharField(max_length=30)),
+                (
+                    "acc",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="revenues",
+                        to="tests.Account",
+                    ),
+                ),
+                (
+                    "project",
+                    django_multitenant.fields.TenantForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="revenues",
+                        to="tests.Project",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
             bases=(django_multitenant.mixins.TenantModelMixin, models.Model),
         ),
-        migrations.RunSQL("ALTER TABLE tests_revenue DROP CONSTRAINT tests_revenue_pkey CASCADE;", reverse_sql=''),
-        tenant_migrations.Distribute('Revenue', reverse_ignore=True),
-        migrations.RunSQL("ALTER TABLE tests_revenue ADD CONSTRAINT tests_revenue_pkey PRIMARY KEY (acc_id, id);", reverse_sql='')
+        migrations.RunSQL(
+            "ALTER TABLE tests_revenue DROP CONSTRAINT tests_revenue_pkey CASCADE;",
+            reverse_sql="",
+        ),
+        tenant_migrations.Distribute("Revenue", reverse_ignore=True),
+        migrations.RunSQL(
+            "ALTER TABLE tests_revenue ADD CONSTRAINT tests_revenue_pkey PRIMARY KEY (acc_id, id);",
+            reverse_sql="",
+        ),
     ]

--- a/django_multitenant/tests/models.py
+++ b/django_multitenant/tests/models.py
@@ -19,14 +19,16 @@ class Account(TenantModel):
     domain = models.CharField(max_length=255)
     subdomain = models.CharField(max_length=255)
     country = models.ForeignKey(Country, on_delete=models.CASCADE)
-    employee = models.ForeignKey('Employee', on_delete=models.CASCADE,
-                                 related_name='accounts',
-                                 null=True,
-                                 blank=True)
-
+    employee = models.ForeignKey(
+        "Employee",
+        on_delete=models.CASCADE,
+        related_name="accounts",
+        null=True,
+        blank=True,
+    )
 
     # TODO change to Meta
-    tenant_id = 'id'
+    tenant_id = "id"
 
     def __str__(self):
         return "{}".format(self.name)
@@ -34,61 +36,75 @@ class Account(TenantModel):
 
 class Employee(models.Model):
     # Reference table
-    account = models.ForeignKey(Account,
-                                on_delete=models.CASCADE,
-                                null=True,
-                                blank=True,
-                                related_name='employees')
-    created_by = models.ForeignKey('self',
-                                   blank=True,
-                                   null=True,
-                                   related_name='users_created',
-                                   on_delete=models.SET_NULL)
+    account = models.ForeignKey(
+        Account,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="employees",
+    )
+    created_by = models.ForeignKey(
+        "self",
+        blank=True,
+        null=True,
+        related_name="users_created",
+        on_delete=models.SET_NULL,
+    )
 
     name = models.CharField(max_length=255)
 
 
 class ModelConfig(TenantModel):
     name = models.CharField(max_length=255)
-    account = models.ForeignKey(Account, on_delete=models.CASCADE,
-                                related_name='configs')
-    employee = models.ForeignKey(Employee, on_delete=models.CASCADE,
-                                 related_name='configs',
-                                 null=True,
-                                 blank=True)
+    account = models.ForeignKey(
+        Account, on_delete=models.CASCADE, related_name="configs"
+    )
+    employee = models.ForeignKey(
+        Employee,
+        on_delete=models.CASCADE,
+        related_name="configs",
+        null=True,
+        blank=True,
+    )
 
-    tenant_id = 'account_id'
+    tenant_id = "account_id"
 
 
 class Manager(TenantModel):
     name = models.CharField(max_length=255)
-    account = models.ForeignKey(Account, on_delete=models.CASCADE,
-                                related_name='managers')
-    tenant_id = 'account_id'
+    account = models.ForeignKey(
+        Account, on_delete=models.CASCADE, related_name="managers"
+    )
+    tenant_id = "account_id"
 
 
 class Project(TenantModel):
     name = models.CharField(max_length=255)
-    account = models.ForeignKey(Account, related_name='projects',
-                                on_delete=models.CASCADE)
-    managers = models.ManyToManyField(Manager, through='ProjectManager')
-    employee = models.ForeignKey(Employee, related_name='projects',
-                                 on_delete=models.SET_NULL,
-                                 null=True,
-                                 blank=True)
-    tenant_id = 'account_id'
+    account = models.ForeignKey(
+        Account, related_name="projects", on_delete=models.CASCADE
+    )
+    managers = models.ManyToManyField(Manager, through="ProjectManager")
+    employee = models.ForeignKey(
+        Employee,
+        related_name="projects",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+    )
+    tenant_id = "account_id"
 
     def __str__(self):
         return "{} ({})".format(self.name, self.account)
 
 
 class ProjectManager(TenantModel):
-    project = TenantForeignKey(Project, on_delete=models.CASCADE,
-                               related_name='projectmanagers')
+    project = TenantForeignKey(
+        Project, on_delete=models.CASCADE, related_name="projectmanagers"
+    )
     manager = TenantForeignKey(Manager, on_delete=models.CASCADE)
     account = models.ForeignKey(Account, on_delete=models.CASCADE)
 
-    tenant_id = 'account_id'
+    tenant_id = "account_id"
 
 
 class TaskQueryset(models.QuerySet):
@@ -111,18 +127,17 @@ class TaskManager(TenantManagerMixin, models.Manager):
 
 class Task(TenantModelMixin, models.Model):
     name = models.CharField(max_length=255)
-    project = TenantForeignKey(Project, on_delete=models.CASCADE,
-                               related_name='tasks')
+    project = TenantForeignKey(Project, on_delete=models.CASCADE, related_name="tasks")
     account = models.ForeignKey(Account, on_delete=models.CASCADE)
     opened = models.BooleanField(default=True)
 
-    parent = TenantForeignKey('self', on_delete=models.CASCADE, db_index=False,
-                              blank=True, null=True)
+    parent = TenantForeignKey(
+        "self", on_delete=models.CASCADE, db_index=False, blank=True, null=True
+    )
 
     objects = TaskManager()
 
-    tenant_id = 'account_id'
-
+    tenant_id = "account_id"
 
     def __str__(self):
         return "{} ({})".format(self.name, self.project)
@@ -135,7 +150,8 @@ class SubTask(TenantModel):
     task = TenantForeignKey(Task, on_delete=models.CASCADE)
     project = TenantForeignKey(Project, on_delete=models.CASCADE, null=True)
 
-    tenant_id = 'account_id'
+    tenant_id = "account_id"
+
 
 class UnscopedModel(models.Model):
     name = models.CharField(max_length=255)
@@ -145,25 +161,25 @@ class AliasedTask(TenantModel):
     project_alias = TenantForeignKey(Project, on_delete=models.CASCADE)
     account = models.ForeignKey(Account, on_delete=models.CASCADE)
 
-    tenant_id = 'account_id'
+    tenant_id = "account_id"
 
 
 class Revenue(TenantModel):
     # To test for correct tenant_id push down in query
-    acc = models.ForeignKey(Account, on_delete=models.CASCADE,
-                            related_name='revenues')
-    project = TenantForeignKey(Project, on_delete=models.CASCADE,
-                               related_name='revenues')
+    acc = models.ForeignKey(Account, on_delete=models.CASCADE, related_name="revenues")
+    project = TenantForeignKey(
+        Project, on_delete=models.CASCADE, related_name="revenues"
+    )
     value = models.CharField(max_length=30)
 
-    tenant_id = 'acc_id'
+    tenant_id = "acc_id"
 
 
 # Models for UUID tests
 class Organization(TenantModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
-    tenant_id = 'id'
+    tenant_id = "id"
 
 
 class Record(TenantModel):
@@ -171,27 +187,26 @@ class Record(TenantModel):
     name = models.CharField(max_length=255)
     organization = TenantForeignKey(Organization, on_delete=models.CASCADE)
 
-    tenant_id = 'organization_id'
-
+    tenant_id = "organization_id"
 
 
 class TenantNotIdModel(TenantModel):
     tenant_column = models.IntegerField(primary_key=True, editable=False)
     name = models.CharField(max_length=255)
 
-    tenant_id = 'tenant_column'
+    tenant_id = "tenant_column"
 
 
 class SomeRelatedModel(TenantModel):
     related_tenant = models.ForeignKey(TenantNotIdModel, on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
 
-    tenant_id = 'related_tenant_id'
+    tenant_id = "related_tenant_id"
 
 
 class MigrationTestModel(TenantModel):
     name = models.CharField(max_length=255)
-    tenant_id = 'id'
+    tenant_id = "id"
 
 
 class MigrationTestReferenceModel(models.Model):

--- a/django_multitenant/tests/settings.py
+++ b/django_multitenant/tests/settings.py
@@ -9,16 +9,13 @@ BASE_PATH = os.path.normpath(
 
 DATABASES = {
     "default": {
-        'ENGINE': 'django_multitenant.backends.postgresql',
+        "ENGINE": "django_multitenant.backends.postgresql",
         "NAME": "postgres",
         "USER": "postgres",
         "PASSWORD": "",
         "HOST": "localhost",
         "PORT": 5600,
-        "TEST": {
-            "NAME": "postgres",
-            "SERIALIZE": False
-        }
+        "TEST": {"NAME": "postgres", "SERIALIZE": False},
     }
 }
 
@@ -56,16 +53,16 @@ ROOT_URLCONF = "django_multitenant.tests.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-                'django.template.context_processors.i18n',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.i18n",
             ],
         },
     },

--- a/django_multitenant/tests/single_node_settings.py
+++ b/django_multitenant/tests/single_node_settings.py
@@ -2,16 +2,13 @@ from .settings import *
 
 DATABASES = {
     "default": {
-        'ENGINE': 'django_multitenant.backends.postgresql',
+        "ENGINE": "django_multitenant.backends.postgresql",
         "NAME": "postgres",
         "USER": "postgres",
         "PASSWORD": "",
         "HOST": "localhost",
         "PORT": 5604,
-        "TEST": {
-            "NAME": "postgres",
-            "SERIALIZE": False
-        }
+        "TEST": {"NAME": "postgres", "SERIALIZE": False},
     }
 }
 

--- a/django_multitenant/tests/test_migrations.py
+++ b/django_multitenant/tests/test_migrations.py
@@ -8,8 +8,8 @@ from django.test import TransactionTestCase
 from django_multitenant.db import migrations
 
 
-
 if settings.USE_CITUS:
+
     class MigrationTest(TransactionTestCase):
         def undistribute_table(self, table_name):
             queries = [
@@ -17,12 +17,12 @@ if settings.USE_CITUS:
                 "CREATE TEMP TABLE %(table_name)s_temp AS SELECT * FROM %(table_name)s;"
                 "INSERT INTO %(table_name)s_bis SELECT * FROM %(table_name)s_temp;"
                 "DROP TABLE %(table_name)s CASCADE;"
-                "ALTER TABLE %(table_name)s_bis RENAME TO %(table_name)s;"]
+                "ALTER TABLE %(table_name)s_bis RENAME TO %(table_name)s;"
+            ]
 
             with connection.cursor() as cursor:
                 for query in queries:
-                    cursor.execute(query % {'table_name': table_name})
-
+                    cursor.execute(query % {"table_name": table_name})
 
         def assertTableIsDistributed(self, table_name, column_name, value=True):
             query = """
@@ -67,44 +67,55 @@ if settings.USE_CITUS:
             return self.assertTableIsReference(table_name, value=False)
 
         def test_distribute_table(self):
-            project_state = ProjectState(real_apps=['tests'])
-            operation = migrations.Distribute('MigrationTestModel')
+            project_state = ProjectState(real_apps=["tests"])
+            operation = migrations.Distribute("MigrationTestModel")
 
-            self.assertEqual(operation.describe(), "Run create_(distributed/reference)_table statement")
+            self.assertEqual(
+                operation.describe(),
+                "Run create_(distributed/reference)_table statement",
+            )
 
-            self.assertTableIsNotDistributed('tests_migrationtestmodel', 'id')
+            self.assertTableIsNotDistributed("tests_migrationtestmodel", "id")
             new_state = project_state.clone()
 
             with connection.schema_editor() as editor:
                 operation.database_forwards("tests", editor, project_state, new_state)
 
-            self.assertTableIsDistributed('tests_migrationtestmodel', 'id')
-            self.undistribute_table('tests_migrationtestmodel')
+            self.assertTableIsDistributed("tests_migrationtestmodel", "id")
+            self.undistribute_table("tests_migrationtestmodel")
 
         def test_reference_table(self):
-            project_state = ProjectState(real_apps=['tests'])
-            operation = migrations.Distribute('MigrationTestReferenceModel', reference=True)
+            project_state = ProjectState(real_apps=["tests"])
+            operation = migrations.Distribute(
+                "MigrationTestReferenceModel", reference=True
+            )
 
-            self.assertEqual(operation.describe(), "Run create_(distributed/reference)_table statement")
-            self.assertTableIsNotReference('tests_migrationtestreferencemodel')
+            self.assertEqual(
+                operation.describe(),
+                "Run create_(distributed/reference)_table statement",
+            )
+            self.assertTableIsNotReference("tests_migrationtestreferencemodel")
             new_state = project_state.clone()
 
             with connection.schema_editor() as editor:
                 operation.database_forwards("tests", editor, project_state, new_state)
 
-            self.assertTableIsReference('tests_migrationtestreferencemodel')
-            self.undistribute_table('tests_migrationtestreferencemodel')
+            self.assertTableIsReference("tests_migrationtestreferencemodel")
+            self.undistribute_table("tests_migrationtestreferencemodel")
 
         def test_reference_different_app_table(self):
-            project_state = ProjectState(real_apps=['auth'])
-            operation = migrations.Distribute('auth.User', reference=True)
+            project_state = ProjectState(real_apps=["auth"])
+            operation = migrations.Distribute("auth.User", reference=True)
 
-            self.assertEqual(operation.describe(), "Run create_(distributed/reference)_table statement")
-            self.assertTableIsNotReference('auth_user')
+            self.assertEqual(
+                operation.describe(),
+                "Run create_(distributed/reference)_table statement",
+            )
+            self.assertTableIsNotReference("auth_user")
             new_state = project_state.clone()
 
             with connection.schema_editor() as editor:
                 operation.database_forwards("tests", editor, project_state, new_state)
 
-            self.assertTableIsReference('auth_user')
-            self.undistribute_table('auth_user')
+            self.assertTableIsReference("auth_user")
+            self.undistribute_table("auth_user")

--- a/django_multitenant/tests/test_models.py
+++ b/django_multitenant/tests/test_models.py
@@ -6,9 +6,11 @@ from django.conf import settings
 from django.db.models import Count
 from django.db.utils import NotSupportedError, DataError
 
-from django_multitenant.utils import (set_current_tenant,
-                                      unset_current_tenant,
-                                      get_current_tenant)
+from django_multitenant.utils import (
+    set_current_tenant,
+    unset_current_tenant,
+    get_current_tenant,
+)
 
 from .base import BaseTestCase
 
@@ -16,6 +18,7 @@ from .base import BaseTestCase
 class TenantModelTest(BaseTestCase):
     def test_filter_without_joins(self):
         from .models import Project
+
         projects = self.projects
         account = self.account_fr
 
@@ -24,9 +27,9 @@ class TenantModelTest(BaseTestCase):
         self.assertEqual(Project.objects.count(), account.projects.count())
         unset_current_tenant()
 
-
     def test_filter_without_joins_on_tenant_id_not_pk(self):
         from .models import TenantNotIdModel, SomeRelatedModel
+
         tenants = self.tenant_not_id
 
         self.assertEqual(SomeRelatedModel.objects.count(), 30)
@@ -36,15 +39,17 @@ class TenantModelTest(BaseTestCase):
 
     def test_select_tenant(self):
         from .models import Project
+
         self.projects
         project = Project.objects.first()
 
         # Selecting the account, account_id being tenant
         with self.assertNumQueries(1) as captured_queries:
             account = project.account
-            self.assertTrue('"tests_account"."id" = %d' % project.account_id \
-                            in captured_queries.captured_queries[0]['sql'])
-
+            self.assertTrue(
+                '"tests_account"."id" = %d' % project.account_id
+                in captured_queries.captured_queries[0]["sql"]
+            )
 
     def test_select_tenant_not_id(self):
         # Test with tenant_id not id field
@@ -56,11 +61,15 @@ class TenantModelTest(BaseTestCase):
         # Selecting the tenant, tenant_column being tenant_id in tests_tenantnodidmodel
         with self.assertNumQueries(1) as captured_queries:
             tenant = some_related.related_tenant
-            self.assertTrue('"tests_tenantnotidmodel"."tenant_column" = %d' % some_related.related_tenant_id \
-                            in captured_queries.captured_queries[0]['sql'])
+            self.assertTrue(
+                '"tests_tenantnotidmodel"."tenant_column" = %d'
+                % some_related.related_tenant_id
+                in captured_queries.captured_queries[0]["sql"]
+            )
 
     def test_select_tenant_foreign_key(self):
         from .models import Task
+
         self.tasks
 
         task = Task.objects.first()
@@ -70,14 +79,16 @@ class TenantModelTest(BaseTestCase):
         # To push down, account_id should be in query
         with self.assertNumQueries(1) as captured_queries:
             project = task.project
-            self.assertTrue('AND "tests_project"."account_id" = %d' % task.account_id \
-                            in captured_queries.captured_queries[0]['sql'])
-
+            self.assertTrue(
+                'AND "tests_project"."account_id" = %d' % task.account_id
+                in captured_queries.captured_queries[0]["sql"]
+            )
 
         unset_current_tenant()
 
     def test_select_tenant_foreign_key_different_tenant_id(self):
         from .models import Revenue, Account
+
         self.revenues
 
         revenue = Revenue.objects.first()
@@ -87,37 +98,48 @@ class TenantModelTest(BaseTestCase):
         # To push down, account_id should be in query (not acc_id)
         with self.assertNumQueries(1) as captured_queries:
             project = revenue.project
-            self.assertTrue('AND "tests_project"."account_id" = %d' % revenue.acc_id \
-                            in captured_queries.captured_queries[0]['sql'])
+            self.assertTrue(
+                'AND "tests_project"."account_id" = %d' % revenue.acc_id
+                in captured_queries.captured_queries[0]["sql"]
+            )
 
         unset_current_tenant()
 
     def test_filter_select_related(self):
         from .models import Task
+
         task_id = self.tasks[0].pk
 
         # Test that the join clause has account_id
         with self.assertNumQueries(1) as captured_queries:
-            task = Task.objects.filter(pk=task_id).select_related('project').first()
+            task = Task.objects.filter(pk=task_id).select_related("project").first()
 
             self.assertEqual(task.account_id, task.project.account_id)
             pattern = 'INNER JOIN "tests_project" ON \("tests_task"."project_id" = "tests_project"."id" AND \("tests_task"."account_id" = .?"tests_project"."account_id"\)\)'
-            self.assertTrue(bool(re.search(pattern, captured_queries.captured_queries[0]['sql'])))
+            self.assertTrue(
+                bool(re.search(pattern, captured_queries.captured_queries[0]["sql"]))
+            )
 
     def test_filter_select_related_not_id_field(self):
         from .models import SomeRelatedModel
+
         tenants = self.tenant_not_id
         some_related_id = SomeRelatedModel.objects.first().pk
         some_related_tenant_id = SomeRelatedModel.objects.first().related_tenant_id
 
         # Test that the join clause has account_id
         with self.assertNumQueries(1) as captured_queries:
-            related = SomeRelatedModel.objects.filter(pk=some_related_id).select_related('related_tenant').first()
+            related = (
+                SomeRelatedModel.objects.filter(pk=some_related_id)
+                .select_related("related_tenant")
+                .first()
+            )
 
             self.assertEqual(related.related_tenant_id, some_related_tenant_id)
-            self.assertTrue('ON ("tests_somerelatedmodel"."related_tenant_id" = "tests_tenantnotidmodel"."tenant_column")' \
-                            in captured_queries.captured_queries[0]['sql'])
-
+            self.assertTrue(
+                'ON ("tests_somerelatedmodel"."related_tenant_id" = "tests_tenantnotidmodel"."tenant_column")'
+                in captured_queries.captured_queries[0]["sql"]
+            )
 
     def test_prefetch_related(self):
         from .models import Project
@@ -128,21 +150,30 @@ class TenantModelTest(BaseTestCase):
         set_current_tenant(account)
 
         with self.assertNumQueries(2) as captured_queries:
-            project = Project.objects.filter(pk=project_id).prefetch_related('managers').first()
+            project = (
+                Project.objects.filter(pk=project_id)
+                .prefetch_related("managers")
+                .first()
+            )
 
-            self.assertTrue('WHERE ("tests_manager"."account_id" = %d' % project.account_id \
-                            in captured_queries.captured_queries[1]['sql'])
+            self.assertTrue(
+                'WHERE ("tests_manager"."account_id" = %d' % project.account_id
+                in captured_queries.captured_queries[1]["sql"]
+            )
             pattern = 'AND \("tests_projectmanager"."account_id" = .?"tests_manager"."account_id"\)'
-            self.assertTrue(bool(re.search(pattern, captured_queries.captured_queries[1]['sql'])))
+            self.assertTrue(
+                bool(re.search(pattern, captured_queries.captured_queries[1]["sql"]))
+            )
 
     def test_create_project(self):
         # Using save()
         from .models import Project
+
         account = self.account_fr
 
         project = Project()
         project.account = account
-        project.name = 'test save()'
+        project.name = "test save()"
 
         project.save()
 
@@ -151,28 +182,30 @@ class TenantModelTest(BaseTestCase):
     def test_create_project_tenant_set(self):
         # Using save()
         from .models import Project
+
         account = self.account_fr
 
         set_current_tenant(account)
         project = Project()
-        project.name = 'test save()'
+        project.name = "test save()"
         project.save()
 
         self.assertEqual(Project.objects.count(), 1)
 
-        Project.objects.create(name='test create')
+        Project.objects.create(name="test create")
         self.assertEqual(Project.objects.count(), 2)
 
         unset_current_tenant()
 
     def test_bulk_create_tenant_set(self):
         from .models import Project
+
         account = self.account_fr
 
         set_current_tenant(account)
         projects = []
         for i in range(10):
-            projects.append(Project(name='project %d' % i))
+            projects.append(Project(name="project %d" % i))
 
         Project.objects.bulk_create(projects)
 
@@ -183,13 +216,13 @@ class TenantModelTest(BaseTestCase):
 
     def test_bulk_create_tenant_not_set(self):
         from .models import Project
+
         account = self.account_fr
 
         unset_current_tenant()
         projects = []
         for i in range(10):
-            projects.append(Project(name='project %d' % i,
-                                    account=account))
+            projects.append(Project(name="project %d" % i, account=account))
 
         Project.objects.bulk_create(projects)
 
@@ -199,22 +232,22 @@ class TenantModelTest(BaseTestCase):
 
         projects = []
         for i in range(10):
-            projects.append(Project(name='project %d' % i))
+            projects.append(Project(name="project %d" % i))
 
         with self.assertRaises(DataError):
             Project.objects.bulk_create(projects)
-
 
     def test_update_tenant_project(self):
         if not settings.USE_CITUS:
             return
 
         from .models import Project
+
         account = self.account_fr
 
         project = Project()
         project.account = account
-        project.name = 'test save()'
+        project.name = "test save()"
 
         project.save()
 
@@ -230,25 +263,27 @@ class TenantModelTest(BaseTestCase):
 
     def test_save_project(self):
         from .models import Project
+
         account = self.account_fr
 
         project = Project()
         project.account = account
-        project.name = 'test save()'
+        project.name = "test save()"
         project.save()
 
         self.assertEqual(Project.objects.count(), 1)
 
         project.account = account
-        project.name = 'test update'
+        project.name = "test update"
         project.save()
 
         project = Project.objects.first()
         self.assertEqual(project.account, account)
-        self.assertEqual(project.name, 'test update')
+        self.assertEqual(project.name, "test update")
 
     def test_delete_tenant_set(self):
         from .models import Project
+
         projects = self.projects
         account = self.account_fr
 
@@ -260,25 +295,26 @@ class TenantModelTest(BaseTestCase):
             unset_current_tenant()
 
             for query in captured_queries.captured_queries:
-                if "tests_revenue" in query['sql']:
-                    self.assertTrue('"acc_id" = %d' % account.id in query['sql'])
+                if "tests_revenue" in query["sql"]:
+                    self.assertTrue('"acc_id" = %d' % account.id in query["sql"])
                 else:
-                    self.assertTrue('"account_id" = %d' % account.id in query['sql'])
+                    self.assertTrue('"account_id" = %d' % account.id in query["sql"])
 
         self.assertEqual(Project.objects.count(), 20)
 
     def test_delete_tenant_not_set(self):
         from .models import Project
+
         projects = self.projects
 
         self.assertEqual(Project.objects.count(), 30)
         Project.objects.all().delete()
         self.assertEqual(Project.objects.count(), 0)
 
-
     def test_subquery(self):
         # we want all the projects with the name of their first task
         import django
+
         if django.VERSION[0] == 1 and django.VERSION[1] < 11:
             # subqueries where only introduced in django 1.11
             return
@@ -294,26 +330,27 @@ class TenantModelTest(BaseTestCase):
 
         set_current_tenant(account)
         with self.assertNumQueries(1) as captured_queries:
-            task_qs = Task.objects.filter(project=OuterRef("pk")).order_by('-name')
+            task_qs = Task.objects.filter(project=OuterRef("pk")).order_by("-name")
             projects = Project.objects.all().annotate(
-                first_task_name=Subquery(
-                    task_qs.values('name')[:1]
-                )
+                first_task_name=Subquery(task_qs.values("name")[:1])
             )
             for p in projects:
                 self.assertTrue(p.first_task_name is not None)
 
             # check that tenant in subquery
             for query in captured_queries.captured_queries:
-                self.assertTrue('U0."account_id" = %d' % account.id in query['sql'])
-                self.assertTrue('WHERE "tests_project"."account_id" = %d' % account.id in query['sql'])
+                self.assertTrue('U0."account_id" = %d' % account.id in query["sql"])
+                self.assertTrue(
+                    'WHERE "tests_project"."account_id" = %d' % account.id
+                    in query["sql"]
+                )
 
         unset_current_tenant()
-
 
     def test_subquery_joins(self):
         # we want all the projects with the name of their first task
         import django
+
         if django.VERSION[0] == 1 and django.VERSION[1] < 11:
             # subqueries where only introduced in django 1.11
             return
@@ -329,25 +366,27 @@ class TenantModelTest(BaseTestCase):
 
         set_current_tenant(account)
         with self.assertNumQueries(1) as captured_queries:
-            subtask_qs = SubTask.objects.filter(project=OuterRef("pk"), task__opened=True).order_by('-name')
+            subtask_qs = SubTask.objects.filter(
+                project=OuterRef("pk"), task__opened=True
+            ).order_by("-name")
             projects = Project.objects.all().annotate(
-                first_subtask_name=Subquery(
-                    subtask_qs.values('name')[:1]
-                )
+                first_subtask_name=Subquery(subtask_qs.values("name")[:1])
             )
             for p in projects:
                 self.assertTrue(p.first_subtask_name is not None)
 
             # check that tenant in subquery
             for query in captured_queries.captured_queries:
-                self.assertTrue('U0."account_id" = %d' % account.id in query['sql'])
+                self.assertTrue('U0."account_id" = %d' % account.id in query["sql"])
 
                 pattern = '\(U0."task_id" = U\d."id" AND \(U0."account_id" = .?U\d."account_id"\)'
-                self.assertTrue(bool(re.search(pattern, query['sql'])))
-                self.assertTrue('WHERE "tests_project"."account_id" = %d' % account.id in query['sql'])
+                self.assertTrue(bool(re.search(pattern, query["sql"])))
+                self.assertTrue(
+                    'WHERE "tests_project"."account_id" = %d' % account.id
+                    in query["sql"]
+                )
 
         unset_current_tenant()
-
 
     def test_task_manager(self):
         from .models import Task
@@ -370,7 +409,6 @@ class TenantModelTest(BaseTestCase):
 
         unset_current_tenant()
 
-
     def test_str_model_tenant_set(self):
         from .models import Task
 
@@ -384,7 +422,6 @@ class TenantModelTest(BaseTestCase):
 
         unset_current_tenant()
 
-
     def test_str_model_tenant_not_set(self):
         from .models import Task
 
@@ -396,6 +433,7 @@ class TenantModelTest(BaseTestCase):
 
     def test_exclude_tenant_set(self):
         from .models import Task
+
         projects = self.projects
         account_fr = self.account_fr
         tasks = self.tasks
@@ -411,6 +449,7 @@ class TenantModelTest(BaseTestCase):
 
     def test_exclude_tenant_not_set(self):
         from .models import Task
+
         projects = self.projects
         account_fr = self.account_fr
         tasks = self.tasks
@@ -418,21 +457,25 @@ class TenantModelTest(BaseTestCase):
         tasks = Task.objects.exclude(project__isnull=True)
         self.assertEqual(tasks.count(), 150)
 
-    @pytest.mark.skipif(not django.VERSION < (3, 2),
-                        reason="Django 3.2 changed the generated query to one that's not supported by Citus")
+    @pytest.mark.skipif(
+        not django.VERSION < (3, 2),
+        reason="Django 3.2 changed the generated query to one that's not supported by Citus",
+    )
     def test_exclude_related(self):
         from .models import Project, Manager, ProjectManager
+
         project = self.projects[0]
         project_managers = self.project_managers
         account = project.account
-        manager = Manager.objects.create(name='Louise', account=account)
+        manager = Manager.objects.create(name="Louise", account=account)
         ProjectManager.objects.create(account=account, project=project, manager=manager)
 
-        excluded = Project.objects.exclude(projectmanagers__manager__name='Louise')
+        excluded = Project.objects.exclude(projectmanagers__manager__name="Louise")
         self.assertEqual(excluded.count(), 29)
 
     def test_delete_cascade_distributed(self):
         from .models import Task, Project, SubTask
+
         subtasks = self.subtasks
         account = self.account_fr
 
@@ -456,23 +499,28 @@ class TenantModelTest(BaseTestCase):
             self.assertEqual(Project.objects.count(), 9)
             self.assertEqual(Task.objects.count(), 45)
             self.assertEqual(SubTask.objects.count(), 225)
-            self.assertFalse("SET LOCAL citus.multi_shard_modify_mode TO 'sequential';" in [query['sql'] for query in captured_queries.captured_queries])
-            self.assertFalse("SET LOCAL citus.multi_shard_modify_mode TO 'parallel';" in [query['sql'] for query in captured_queries.captured_queries])
+            self.assertFalse(
+                "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
+                in [query["sql"] for query in captured_queries.captured_queries]
+            )
+            self.assertFalse(
+                "SET LOCAL citus.multi_shard_modify_mode TO 'parallel';"
+                in [query["sql"] for query in captured_queries.captured_queries]
+            )
 
     def test_delete_cascade_reference_to_distributed(self):
         from .models import Country, Account
+
         unset_current_tenant()
 
         country = self.france
-        account1 = Account.objects.create(name='Account FR',
-                                          country=country,
-                                          subdomain='fr.',
-                                          domain='citusdata.com')
+        account1 = Account.objects.create(
+            name="Account FR", country=country, subdomain="fr.", domain="citusdata.com"
+        )
 
-        account2 = Account.objects.create(name='Account FR 2',
-                                          country=country,
-                                          subdomain='fr.',
-                                          domain='msft.com')
+        account2 = Account.objects.create(
+            name="Account FR 2", country=country, subdomain="fr.", domain="msft.com"
+        )
 
         self.assertEqual(Account.objects.count(), 2)
 
@@ -481,25 +529,31 @@ class TenantModelTest(BaseTestCase):
 
             self.assertEqual(Account.objects.count(), 0)
             self.assertEqual(Country.objects.count(), 0)
-            self.assertTrue("SET LOCAL citus.multi_shard_modify_mode TO 'sequential';" in [query['sql'] for query in captured_queries.captured_queries])
-            self.assertTrue("SET LOCAL citus.multi_shard_modify_mode TO 'parallel';" in [query['sql'] for query in captured_queries.captured_queries])
+            self.assertTrue(
+                "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
+                in [query["sql"] for query in captured_queries.captured_queries]
+            )
+            self.assertTrue(
+                "SET LOCAL citus.multi_shard_modify_mode TO 'parallel';"
+                in [query["sql"] for query in captured_queries.captured_queries]
+            )
 
     def test_delete_cascade_distributed_to_reference(self):
         from .models import Account, Employee, ModelConfig, Project
+
         unset_current_tenant()
 
         account = self.account_fr
-        employee = Employee.objects.create(account=account, name='Louise')
-        modelconfig = ModelConfig.objects.create(account=account,
-                                                 employee=employee,
-                                                 name='test')
+        employee = Employee.objects.create(account=account, name="Louise")
+        modelconfig = ModelConfig.objects.create(
+            account=account, employee=employee, name="test"
+        )
         projects = self.projects
-
 
         for project in projects:
             if project.account == account:
                 project.employee = employee
-                project.save(update_fields=['employee'])
+                project.save(update_fields=["employee"])
 
         account.employee = employee
         account.save()
@@ -518,8 +572,14 @@ class TenantModelTest(BaseTestCase):
             self.assertEqual(Employee.objects.count(), 0)
             self.assertEqual(ModelConfig.objects.count(), 0)
             self.assertEqual(Project.objects.count(), 20)
-            self.assertTrue("SET LOCAL citus.multi_shard_modify_mode TO 'sequential';" in [query['sql'] for query in captured_queries.captured_queries])
-            self.assertTrue("SET LOCAL citus.multi_shard_modify_mode TO 'parallel';" in [query['sql'] for query in captured_queries.captured_queries])
+            self.assertTrue(
+                "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
+                in [query["sql"] for query in captured_queries.captured_queries]
+            )
+            self.assertTrue(
+                "SET LOCAL citus.multi_shard_modify_mode TO 'parallel';"
+                in [query["sql"] for query in captured_queries.captured_queries]
+            )
 
         unset_current_tenant()
 
@@ -527,9 +587,10 @@ class TenantModelTest(BaseTestCase):
 class MultipleTenantModelTest(BaseTestCase):
     def test_filter_without_joins(self):
         from .models import Project, Account
+
         unset_current_tenant()
         projects = self.projects
-        accounts = Account.objects.all().order_by('id')[1:]
+        accounts = Account.objects.all().order_by("id")[1:]
 
         self.assertEqual(Project.objects.count(), 30)
         set_current_tenant(accounts)
@@ -539,6 +600,7 @@ class MultipleTenantModelTest(BaseTestCase):
 
     def test_filter_without_joins_on_tenant_id_not_pk(self):
         from .models import TenantNotIdModel, SomeRelatedModel
+
         unset_current_tenant()
         tenants = self.tenant_not_id
 
@@ -550,6 +612,7 @@ class MultipleTenantModelTest(BaseTestCase):
 
     def test_select_tenant_foreign_key(self):
         from .models import Task, Account
+
         unset_current_tenant()
         self.tasks
 
@@ -561,13 +624,17 @@ class MultipleTenantModelTest(BaseTestCase):
         # To push down, account_id should be in query
         with self.assertNumQueries(1) as captured_queries:
             project = task.project
-            self.assertTrue('AND "tests_project"."account_id" IN (%s)' % ', '.join([str(account.id) for account in accounts]) \
-                            in captured_queries.captured_queries[0]['sql'])
+            self.assertTrue(
+                'AND "tests_project"."account_id" IN (%s)'
+                % ", ".join([str(account.id) for account in accounts])
+                in captured_queries.captured_queries[0]["sql"]
+            )
 
         unset_current_tenant()
 
     def test_select_tenant_foreign_key_different_tenant_id(self):
         from .models import Revenue, Account
+
         unset_current_tenant()
         self.revenues
 
@@ -579,13 +646,17 @@ class MultipleTenantModelTest(BaseTestCase):
         # To push down, account_id should be in query (not acc_id)
         with self.assertNumQueries(1) as captured_queries:
             project = revenue.project
-            self.assertTrue('AND "tests_project"."account_id" IN (%s)' % ', '.join([str(account.id) for account in accounts]) \
-                            in captured_queries.captured_queries[0]['sql'])
+            self.assertTrue(
+                'AND "tests_project"."account_id" IN (%s)'
+                % ", ".join([str(account.id) for account in accounts])
+                in captured_queries.captured_queries[0]["sql"]
+            )
 
         unset_current_tenant()
 
     def test_prefetch_related(self):
         from .models import Project, Account
+
         unset_current_tenant()
         project_managers = self.project_managers
         project_id = project_managers[0].project_id
@@ -593,21 +664,31 @@ class MultipleTenantModelTest(BaseTestCase):
         set_current_tenant(accounts)
 
         with self.assertNumQueries(2) as captured_queries:
-            project = Project.objects.filter(pk=project_id).prefetch_related('managers').first()
+            project = (
+                Project.objects.filter(pk=project_id)
+                .prefetch_related("managers")
+                .first()
+            )
 
-            self.assertTrue('WHERE ("tests_manager"."account_id" IN (%s)' % ', '.join([str(account.id) for account in accounts]) \
-                            in captured_queries.captured_queries[1]['sql'])
+            self.assertTrue(
+                'WHERE ("tests_manager"."account_id" IN (%s)'
+                % ", ".join([str(account.id) for account in accounts])
+                in captured_queries.captured_queries[1]["sql"]
+            )
 
             pattern = 'AND \("tests_projectmanager"."account_id" = .?"tests_manager"."account_id"\)'
-            self.assertTrue(bool(re.search(pattern, captured_queries.captured_queries[1]['sql'])))
+            self.assertTrue(
+                bool(re.search(pattern, captured_queries.captured_queries[1]["sql"]))
+            )
 
         unset_current_tenant()
 
     def test_delete_tenant_set(self):
         from .models import Project, Account
+
         unset_current_tenant()
         projects = self.projects
-        accounts = Account.objects.all().order_by('id')[1:]
+        accounts = Account.objects.all().order_by("id")[1:]
         self.assertEqual(Project.objects.count(), 30)
 
         set_current_tenant(accounts)
@@ -615,33 +696,39 @@ class MultipleTenantModelTest(BaseTestCase):
             Project.objects.all().delete()
 
             for query in captured_queries.captured_queries:
-                if "tests_revenue" in query['sql']:
-                    self.assertTrue('"acc_id" IN (%s)' % ', '.join([str(account.id) for account in accounts]))
+                if "tests_revenue" in query["sql"]:
+                    self.assertTrue(
+                        '"acc_id" IN (%s)'
+                        % ", ".join([str(account.id) for account in accounts])
+                    )
                 else:
-                    self.assertTrue('"account_id" IN (%s)' % ', '.join([str(account.id) for account in accounts]))
+                    self.assertTrue(
+                        '"account_id" IN (%s)'
+                        % ", ".join([str(account.id) for account in accounts])
+                    )
 
         unset_current_tenant()
         self.assertEqual(Project.objects.count(), 10)
-
 
     def test_subquery(self):
         # subquery don't work for multi tenants
         # we want all the projects with the name of their first task
         pass
 
-
     def test_uuid_create(self):
         from .models import Record
+
         organization = self.organization
         set_current_tenant(organization)
-        record = Record.objects.create(name='record1')
+        record = Record.objects.create(name="record1")
         self.assertEqual(record.organization_id, organization.id)
 
     def test_uuid_save(self):
         from .models import Record
+
         organization = self.organization
         set_current_tenant(organization)
-        record = Record(name='record1')
+        record = Record(name="record1")
         record.save()
 
         record = Record.objects.first()
@@ -650,41 +737,43 @@ class MultipleTenantModelTest(BaseTestCase):
     def test_save_tenant_unset(self):
         unset_current_tenant()
         from .models import Project
+
         account = self.account_fr
 
         account_2 = self.account_us
 
-        project = Project(account=account, name='test save fr')
+        project = Project(account=account, name="test save fr")
         project.save()
 
-        project2 = Project(account=account_2, name='test save us')
+        project2 = Project(account=account_2, name="test save us")
         project2.save()
 
         self.assertEqual(Project.objects.count(), 2)
 
-        project.name = 'test update name'
+        project.name = "test update name"
         project.save()
 
         project = Project.objects.first()
-        self.assertEqual(project.name, 'test update name')
+        self.assertEqual(project.name, "test update name")
 
     def test_save_tenant_set_different_than_object(self):
         unset_current_tenant()
         from .models import Project
+
         account = self.account_fr
         account_2 = self.account_us
 
-        project = Project(account=account, name='test save fr')
+        project = Project(account=account, name="test save fr")
         project.save()
 
-        project2 = Project(account=account_2, name='test save us')
+        project2 = Project(account=account_2, name="test save us")
         project2.save()
 
         self.assertEqual(Project.objects.count(), 2)
 
         set_current_tenant(account_2)
 
-        project.name = 'test update name'
+        project.name = "test update name"
         project.save()
 
         current_tenant = get_current_tenant()
@@ -692,25 +781,26 @@ class MultipleTenantModelTest(BaseTestCase):
 
         unset_current_tenant()
         project = Project.objects.filter(account=account).first()
-        self.assertEqual(project.name, 'test update name')
+        self.assertEqual(project.name, "test update name")
 
     def test_save_tenant_set(self):
         unset_current_tenant()
         from .models import Project
+
         account = self.account_fr
         account_2 = self.account_us
 
-        project = Project(account=account, name='test save fr')
+        project = Project(account=account, name="test save fr")
         project.save()
 
-        project2 = Project(account=account_2, name='test save us')
+        project2 = Project(account=account_2, name="test save us")
         project2.save()
 
         self.assertEqual(Project.objects.count(), 2)
 
         set_current_tenant(account)
 
-        project.name = 'test update name'
+        project.name = "test update name"
         project.save()
 
         current_tenant = get_current_tenant()
@@ -718,12 +808,13 @@ class MultipleTenantModelTest(BaseTestCase):
 
         unset_current_tenant()
         project = Project.objects.filter(account=account).first()
-        self.assertEqual(project.name, 'test update name')
+        self.assertEqual(project.name, "test update name")
 
     def test_aggregate(self):
         from .models import ProjectManager
+
         projects = self.projects
         managers = self.project_managers
         unset_current_tenant()
-        projects_per_manager = ProjectManager.objects.annotate(Count('project_id'))
+        projects_per_manager = ProjectManager.objects.annotate(Count("project_id"))
         list(projects_per_manager)

--- a/django_multitenant/tests/test_utils.py
+++ b/django_multitenant/tests/test_utils.py
@@ -1,9 +1,11 @@
-from django_multitenant.utils import (set_current_tenant,
-                                      get_current_tenant,
-                                      unset_current_tenant,
-                                      get_tenant_column,
-                                      get_current_tenant_value,
-                                      get_tenant_filters)
+from django_multitenant.utils import (
+    set_current_tenant,
+    get_current_tenant,
+    unset_current_tenant,
+    get_tenant_column,
+    get_current_tenant_value,
+    get_tenant_filters,
+)
 
 from .base import BaseTestCase
 
@@ -11,6 +13,7 @@ from .base import BaseTestCase
 class UtilsTest(BaseTestCase):
     def test_set_current_tenant(self):
         from .models import Project
+
         projects = self.projects
         account = projects[0].account
 
@@ -20,17 +23,18 @@ class UtilsTest(BaseTestCase):
 
     def test_get_tenant_column(self):
         from .models import Project
+
         projects = self.projects
         account = projects[0].account
 
         # test if instance
         column = get_tenant_column(account)
-        self.assertEqual(column, 'id')
+        self.assertEqual(column, "id")
         self.assertEqual(get_tenant_column(account), account.tenant_field)
 
         # test if  model
         column = get_tenant_column(Project)
-        self.assertEqual(column, 'account_id')
+        self.assertEqual(column, "account_id")
 
     def test_current_tenant_value_single(self):
         from .models import Project, Account
@@ -61,13 +65,13 @@ class UtilsTest(BaseTestCase):
         from .models import Project, Account
 
         projects = self.projects
-        accounts = Account.objects.all().order_by('id')
+        accounts = Account.objects.all().order_by("id")
         set_current_tenant(accounts)
 
         value = get_current_tenant_value()
 
         self.assertTrue(isinstance(value, list))
-        self.assertEqual(value, accounts.values_list('id', flat=True))
+        self.assertEqual(value, accounts.values_list("id", flat=True))
 
         unset_current_tenant()
 
@@ -78,7 +82,7 @@ class UtilsTest(BaseTestCase):
         account = projects[0].account
         set_current_tenant(account)
 
-        self.assertEqual(get_tenant_filters(Project), {'account_id': account.pk})
+        self.assertEqual(get_tenant_filters(Project), {"account_id": account.pk})
 
         unset_current_tenant()
 
@@ -89,8 +93,10 @@ class UtilsTest(BaseTestCase):
         accounts = [projects[0].account, projects[1].account]
         set_current_tenant(accounts)
 
-        self.assertEqual(get_tenant_filters(Project),
-                         {'account_id__in': [accounts[0].id, accounts[1].id]})
+        self.assertEqual(
+            get_tenant_filters(Project),
+            {"account_id__in": [accounts[0].id, accounts[1].id]},
+        )
 
         unset_current_tenant()
 
@@ -98,11 +104,13 @@ class UtilsTest(BaseTestCase):
         from .models import Project, Account
 
         projects = self.projects
-        accounts = Account.objects.all().order_by('id')
+        accounts = Account.objects.all().order_by("id")
         set_current_tenant(accounts)
 
         value = get_current_tenant_value()
 
-        self.assertEqual(get_tenant_filters(Project),
-                         {'account_id__in': list(accounts.values_list('id', flat=True))})
+        self.assertEqual(
+            get_tenant_filters(Project),
+            {"account_id__in": list(accounts.values_list("id", flat=True))},
+        )
         unset_current_tenant()

--- a/django_multitenant/utils.py
+++ b/django_multitenant/utils.py
@@ -17,7 +17,7 @@ def get_model_by_db_table(db_table):
             return model
     else:
         # here you can do fallback logic if no model with db_table found
-        raise ValueError('No model found with db_table {}!'.format(db_table))
+        raise ValueError("No model found with db_table {}!".format(db_table))
         # or return None
 
 
@@ -30,7 +30,7 @@ def get_current_tenant():
     ```
     Will return None if the tenant is not set
     """
-    return getattr(_thread_locals, 'tenant', None)
+    return getattr(_thread_locals, "tenant", None)
 
 
 def get_tenant_column(model_class_or_instance):
@@ -40,9 +40,11 @@ def get_tenant_column(model_class_or_instance):
     try:
         return model_class_or_instance.tenant_field
     except:
-        raise ValueError('''%s is not an instance or a subclass of TenantModel
-                         or does not inherit from TenantMixin'''
-                         % model_class_or_instance.__class__.__name__)
+        raise ValueError(
+            """%s is not an instance or a subclass of TenantModel
+                         or does not inherit from TenantMixin"""
+            % model_class_or_instance.__class__.__name__
+        )
 
 
 def get_tenant_field(model_class_or_instance):
@@ -51,8 +53,11 @@ def get_tenant_field(model_class_or_instance):
     try:
         return next(field for field in all_fields if field.column == tenant_column)
     except StopIteration:
-        raise ValueError('No field found in {} with column name "{}"'.format(
-                         model_class_or_instance, tenant_column))
+        raise ValueError(
+            'No field found in {} with column name "{}"'.format(
+                model_class_or_instance, tenant_column
+            )
+        )
 
 
 def get_object_tenant(instance):
@@ -94,7 +99,7 @@ def get_tenant_filters(table, filters=None):
         return filters
 
     if isinstance(current_tenant_value, list):
-        filters['%s__in' % get_tenant_column(table)] = current_tenant_value
+        filters["%s__in" % get_tenant_column(table)] = current_tenant_value
     else:
         filters[get_tenant_column(table)] = current_tenant_value
 
@@ -112,11 +117,11 @@ def set_current_tenant(tenant):
     ```
     """
 
-    setattr(_thread_locals, 'tenant', tenant)
+    setattr(_thread_locals, "tenant", tenant)
 
 
 def unset_current_tenant():
-    setattr(_thread_locals, 'tenant', None)
+    setattr(_thread_locals, "tenant", None)
 
 
 def is_distributed_model(model):

--- a/manage.py
+++ b/manage.py
@@ -3,19 +3,20 @@ import os
 import sys
 
 
-SUPPORTED_ENVS = ('tests')
+SUPPORTED_ENVS = "tests"
 
 SETTINGS_MODULES = {
-    'test': 'django_multitenant.tests.settings',
+    "test": "django_multitenant.tests.settings",
 }
 
-ENV = os.environ.get('ENV', 'test')
+ENV = os.environ.get("ENV", "test")
 ENV = ENV.lower()
 
 if ENV not in SUPPORTED_ENVS:
-    raise Exception('Unsupported environment: %s' % ENV)
+    raise Exception("Unsupported environment: %s" % ENV)
 
-if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', SETTINGS_MODULES[ENV])
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", SETTINGS_MODULES[ENV])
     from django.core.management import execute_from_command_line
+
     execute_from_command_line(sys.argv)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,3 +6,4 @@ pytest-cov
 pytest-django
 exam
 ipdb
+black

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,13 @@ with open(path.join(this_directory, "README.md")) as f:
 
 setup(
     name="django-multitenant",
-    version='2.4.0',  # Required
-    description='Django Library to Implement Multi-tenant databases',
+    version="2.4.0",  # Required
+    description="Django Library to Implement Multi-tenant databases",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     url="https://github.com/citusdata/django-multitenant",
-    author='Louise Grandjonc',
-    author_email='louise.grandjonc@microsoft.com',
-
+    author="Louise Grandjonc",
+    author_email="louise.grandjonc@microsoft.com",
     # Classifiers help users find your project by categorizing it.
     #
     # For a list of valid classifiers, see https://pypi.org/classifiers/
@@ -29,10 +28,8 @@ setup(
         "Development Status :: 5 - Production/Stable ",
         "Topic :: Database",
         "License :: OSI Approved :: MIT License",
-        "Intended Audience :: Developers"
+        "Intended Audience :: Developers",
     ],
-
-    keywords=("citus django multi tenant"
-              "django postgres multi-tenant"),
+    keywords=("citus django multi tenant" "django postgres multi-tenant"),
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,7 @@
 [tox]
 envlist =
+    {py39}-django{32,31,22}
     {py27}-django{111}
-    {py39}-django{22}
-    {py39}-django{31}
-    {py39}-django{32}
 
 [testenv]
 basepython =
@@ -12,10 +10,11 @@ basepython =
 
 deps =
     -r{toxinidir}/requirements/tox.txt
-    {py27}-django111: Django>=1.11,<2.0
-    {py39}-django22: Django>=2.2,<3.0
-    {py39}-django31: Django>=3.1,<3.2
-    {py39}-django32: Django>=3.2,<3.3
+    py27-django111: Django>=1.11,<2.0
+    py39-django22: Django>=2.2,<3.0
+    py39-django31: Django>=3.1,<3.2
+    py39-django32: Django>=3.2,<3.3
+    py39-django32: black
 
 setenv =
     PYTHONPATH = {toxinidir}
@@ -23,5 +22,6 @@ whitelist_externals =
     make
 changedir = {toxinidir}
 commands =
+   py39-django32: make format-check
    make test
    make revert-test-migrations


### PR DESCRIPTION
Having a consistent codestyle is very useful. By using `black` we can
autoformat code to be in a consistent style, without having to spend
effort manually formatting code.