### PR TITLE
Fix all deprecation warnings

### DIFF
--- a/django_multitenant/__init__.py
+++ b/django_multitenant/__init__.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
+import django
+
 version = (2, 3, 2)
 
 __version__ = ".".join(map(str, version))
 
-default_app_config = "django_multitenant.apps.MultitenantConfig"
+if django.VERSION < (3, 2):
+    default_app_config = "django_multitenant.apps.MultitenantConfig"
 
 __all__ = ["default_app_config", "version"]

--- a/django_multitenant/__init__.py
+++ b/django_multitenant/__init__.py
@@ -5,6 +5,8 @@ version = (2, 3, 2)
 
 __version__ = ".".join(map(str, version))
 
+# default_app_config is auto detected for versions 3.2 and higher:
+# https://docs.djangoproject.com/en/3.2/ref/applications/#for-application-authors
 if django.VERSION < (3, 2):
     default_app_config = "django_multitenant.apps.MultitenantConfig"
 

--- a/django_multitenant/fields.py
+++ b/django_multitenant/fields.py
@@ -38,7 +38,7 @@ class TenantForeignKey(models.ForeignKey):
         if current_tenant:
             return get_tenant_filters(self.related_model)
         else:
-            logger.warn(
+            logger.warning(
                 "TenantForeignKey field %s.%s "
                 "accessed without a current tenant set. "
                 "This may cause issues in a partitioned environment. "

--- a/django_multitenant/tests/settings.py
+++ b/django_multitenant/tests/settings.py
@@ -22,7 +22,7 @@ DATABASES = {
 SITE_ID = 1
 DEBUG = True
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -32,8 +32,6 @@ MIDDLEWARE_CLASSES = (
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 )
 
-
-MIDDLEWARE = MIDDLEWARE_CLASSES
 
 INSTALLED_APPS = [
     "django.contrib.admin",
@@ -70,3 +68,5 @@ TEMPLATES = [
 
 USE_CITUS = True
 CITUS_EXTENSION_INSTALLED = True
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/django_multitenant/tests/test_models.py
+++ b/django_multitenant/tests/test_models.py
@@ -115,7 +115,7 @@ class TenantModelTest(BaseTestCase):
             task = Task.objects.filter(pk=task_id).select_related("project").first()
 
             self.assertEqual(task.account_id, task.project.account_id)
-            pattern = 'INNER JOIN "tests_project" ON \("tests_task"."project_id" = "tests_project"."id" AND \("tests_task"."account_id" = .?"tests_project"."account_id"\)\)'
+            pattern = 'INNER JOIN "tests_project" ON \\("tests_task"."project_id" = "tests_project"."id" AND \\("tests_task"."account_id" = .?"tests_project"."account_id"\\)\\)'
             self.assertTrue(
                 bool(re.search(pattern, captured_queries.captured_queries[0]["sql"]))
             )
@@ -160,7 +160,7 @@ class TenantModelTest(BaseTestCase):
                 'WHERE ("tests_manager"."account_id" = %d' % project.account_id
                 in captured_queries.captured_queries[1]["sql"]
             )
-            pattern = 'AND \("tests_projectmanager"."account_id" = .?"tests_manager"."account_id"\)'
+            pattern = 'AND \\("tests_projectmanager"."account_id" = .?"tests_manager"."account_id"\\)'
             self.assertTrue(
                 bool(re.search(pattern, captured_queries.captured_queries[1]["sql"]))
             )
@@ -379,7 +379,7 @@ class TenantModelTest(BaseTestCase):
             for query in captured_queries.captured_queries:
                 self.assertTrue('U0."account_id" = %d' % account.id in query["sql"])
 
-                pattern = '\(U0."task_id" = U\d."id" AND \(U0."account_id" = .?U\d."account_id"\)'
+                pattern = '\\(U0."task_id" = U\\d."id" AND \\(U0."account_id" = .?U\\d."account_id"\\)'
                 self.assertTrue(bool(re.search(pattern, query["sql"])))
                 self.assertTrue(
                     'WHERE "tests_project"."account_id" = %d' % account.id
@@ -676,7 +676,7 @@ class MultipleTenantModelTest(BaseTestCase):
                 in captured_queries.captured_queries[1]["sql"]
             )
 
-            pattern = 'AND \("tests_projectmanager"."account_id" = .?"tests_manager"."account_id"\)'
+            pattern = 'AND \\("tests_projectmanager"."account_id" = .?"tests_manager"."account_id"\\)'
             self.assertTrue(
                 bool(re.search(pattern, captured_queries.captured_queries[1]["sql"]))
             )

--- a/django_multitenant/tests/urls.py
+++ b/django_multitenant/tests/urls.py
@@ -1,5 +1,12 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import include, url
+import django
+from django.conf.urls import include
+
+if django.VERSION >= (3, 1):
+    from django.urls import re_path as url
+else:
+    from django.conf.urls import url
+
 from django.contrib import admin
 
 

--- a/django_multitenant/tests/urls.py
+++ b/django_multitenant/tests/urls.py
@@ -2,6 +2,9 @@
 import django
 from django.conf.urls import include
 
+# django.conf.urls.url is deprecated since Django 3.1, re_path is the
+# replacement:
+# https://docs.djangoproject.com/en/3.1/ref/urls/#url
 if django.VERSION >= (3, 1):
     from django.urls import re_path as url
 else:


### PR DESCRIPTION
This fixes all deprecation warnings that test output was showing. This is in preparation of Django 4.0 support.