### PR TITLE
Support Django 4.0 and drop 1.11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ https://www.citusdata.com/blog/2016/10/03/designing-your-saas-database-for-high-
 
 | Python        | Django        |
 | ------------- | -------------:|
-| 2.7           | 1.11          |
 | 3.X           | 2.2           |
 | 3.X           | 3.1           |
 | 3.X           | 3.2           |
+| 3.X           | 4.0           |
 
 
 ## Usage:

--- a/django_multitenant/backends/postgresql/base.py
+++ b/django_multitenant/backends/postgresql/base.py
@@ -93,7 +93,9 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
             return self.sql_create_fk % {
                 "table": self.quote_name(model._meta.db_table),
                 "name": self.quote_name(
-                    self._create_index_name(model, from_columns, suffix=suffix)
+                    self._create_index_name(
+                        model._meta.db_table, from_columns, suffix=suffix
+                    )
                 ),
                 "column": ", ".join(
                     [self.quote_name(from_col) for from_col in from_columns]
@@ -116,17 +118,6 @@ class DatabaseSchemaEditor(PostgresqlDatabaseSchemaEditor):
                     super(DatabaseSchemaEditor, self).execute(statement)
         elif sql:
             super(DatabaseSchemaEditor, self).execute(sql, params)
-
-    def _create_index_name(self, model, column_names, suffix=""):
-        # compat with django 2.X and django 1.X
-        import django
-
-        if not isinstance(model, str) and django.VERSION[0] > 1:
-            model = model._meta.db_table
-
-        return super(DatabaseSchemaEditor, self)._create_index_name(
-            model, column_names, suffix=suffix
-        )
 
 
 class DatabaseFeatures(PostgresqlDatabaseFeatures):

--- a/django_multitenant/query.py
+++ b/django_multitenant/query.py
@@ -5,6 +5,7 @@ from django.db.models.sql.constants import (
     NO_RESULTS,
 )
 from django.conf import settings
+from django.db.models.sql.where import WhereNode
 
 
 from .utils import (
@@ -39,7 +40,7 @@ def wrap_update_batch(base_update_batch):
     def update_batch(obj, pk_list, values, using):
         obj.add_update_values(values)
         for offset in range(0, len(pk_list), GET_ITERATOR_CHUNK_SIZE):
-            obj.where = obj.where_class()
+            obj.where = WhereNode()
             obj.add_q(Q(pk__in=pk_list[offset : offset + GET_ITERATOR_CHUNK_SIZE]))
             add_tenant_filters_on_query(obj)
             obj.get_compiler(using).execute_sql(NO_RESULTS)

--- a/django_multitenant/tests/settings.py
+++ b/django_multitenant/tests/settings.py
@@ -7,6 +7,11 @@ BASE_PATH = os.path.normpath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir)
 )
 
+if django.VERSION >= (4, 0):
+    test_db = {"NAME": "postgres"}
+else:
+    test_db = {"NAME": "postgres", "SERIALIZE": False}
+
 DATABASES = {
     "default": {
         "ENGINE": "django_multitenant.backends.postgresql",
@@ -15,7 +20,7 @@ DATABASES = {
         "PASSWORD": "",
         "HOST": "localhost",
         "PORT": 5600,
-        "TEST": {"NAME": "postgres", "SERIALIZE": False},
+        "TEST": test_db,
     }
 }
 
@@ -70,3 +75,4 @@ USE_CITUS = True
 CITUS_EXTENSION_INSTALLED = True
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+USE_TZ = True

--- a/django_multitenant/tests/single_node_settings.py
+++ b/django_multitenant/tests/single_node_settings.py
@@ -1,16 +1,6 @@
 from .settings import *
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django_multitenant.backends.postgresql",
-        "NAME": "postgres",
-        "USER": "postgres",
-        "PASSWORD": "",
-        "HOST": "localhost",
-        "PORT": 5604,
-        "TEST": {"NAME": "postgres", "SERIALIZE": False},
-    }
-}
 
+DATABASES["default"]["PORT"] = 5604
 
 USE_CITUS = False

--- a/django_multitenant/tests/test_migrations.py
+++ b/django_multitenant/tests/test_migrations.py
@@ -67,7 +67,7 @@ if settings.USE_CITUS:
             return self.assertTableIsReference(table_name, value=False)
 
         def test_distribute_table(self):
-            project_state = ProjectState(real_apps=["tests"])
+            project_state = ProjectState(real_apps={"tests"})
             operation = migrations.Distribute("MigrationTestModel")
 
             self.assertEqual(
@@ -85,7 +85,7 @@ if settings.USE_CITUS:
             self.undistribute_table("tests_migrationtestmodel")
 
         def test_reference_table(self):
-            project_state = ProjectState(real_apps=["tests"])
+            project_state = ProjectState(real_apps={"tests"})
             operation = migrations.Distribute(
                 "MigrationTestReferenceModel", reference=True
             )
@@ -104,7 +104,7 @@ if settings.USE_CITUS:
             self.undistribute_table("tests_migrationtestreferencemodel")
 
         def test_reference_different_app_table(self):
-            project_state = ProjectState(real_apps=["auth"])
+            project_state = ProjectState(real_apps={"auth"})
             operation = migrations.Distribute("auth.User", reference=True)
 
             self.assertEqual(

--- a/django_multitenant/tests/test_models.py
+++ b/django_multitenant/tests/test_models.py
@@ -315,10 +315,6 @@ class TenantModelTest(BaseTestCase):
         # we want all the projects with the name of their first task
         import django
 
-        if django.VERSION[0] == 1 and django.VERSION[1] < 11:
-            # subqueries where only introduced in django 1.11
-            return
-
         from django.db.models import OuterRef, Subquery
         from .models import Project, Task
 
@@ -350,10 +346,6 @@ class TenantModelTest(BaseTestCase):
     def test_subquery_joins(self):
         # we want all the projects with the name of their first task
         import django
-
-        if django.VERSION[0] == 1 and django.VERSION[1] < 11:
-            # subqueries where only introduced in django 1.11
-            return
 
         from django.db.models import OuterRef, Subquery
         from .models import Project, SubTask

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "Topic :: Database",
         "License :: OSI Approved :: MIT License",
         "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3 :: Only",
     ],
     keywords=("citus django multi tenant" "django postgres multi-tenant"),
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,18 @@
 [tox]
 envlist =
-    {py39}-django{32,31,22}
-    {py27}-django{111}
+    {py39}-django{40,32,31,22}
 
 [testenv]
 basepython =
-    py27: python2.7
     py39: python3.9
 
 deps =
     -r{toxinidir}/requirements/tox.txt
-    py27-django111: Django>=1.11,<2.0
     py39-django22: Django>=2.2,<3.0
     py39-django31: Django>=3.1,<3.2
     py39-django32: Django>=3.2,<3.3
-    py39-django32: black
+    py39-django40: Django>=4.0,<4.1
+    py39-django40: black
 
 setenv =
     PYTHONPATH = {toxinidir}
@@ -22,6 +20,6 @@ whitelist_externals =
     make
 changedir = {toxinidir}
 commands =
-   py39-django32: make format-check
+   py39-django40: make format-check
    make test
    make revert-test-migrations


### PR DESCRIPTION
Modify the code to work with Django 4.0. The main change in 4.0 that
broke some things was that `where_class` was not available anymore. This
could be replaced using `WhereNode` in all supported Django versions.

Some fixes to the test code for Django 4.0 broke those same tests on
Django 1.11. To solve this we could have added version checks to make
this test code work on Django 1.11. Instead it was decided to drop
Django 1.11 support and with that also Python 2.7 support. So this 
change also removes all Django 1.11 compatibility code.

Python 2.7 its EOL is 2020-01-01 and Django 1.11 its EOL is
2020-04-01. Given both these EOLs are more than 1.5 years ago at this
point, it seems fine to drop their support for future versions of this
library.

