### PR TITLE
Drop support for EOL Django 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ https://www.citusdata.com/blog/2016/10/03/designing-your-saas-database-for-high-
 | Python        | Django        |
 | ------------- | -------------:|
 | 3.X           | 2.2           |
-| 3.X           | 3.1           |
 | 3.X           | 3.2           |
 | 3.X           | 4.0           |
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py39}-django{40,32,31,22}
+    {py39}-django{40,32,22}
 
 [testenv]
 basepython =
@@ -9,7 +9,6 @@ basepython =
 deps =
     -r{toxinidir}/requirements/tox.txt
     py39-django22: Django>=2.2,<3.0
-    py39-django31: Django>=3.1,<3.2
     py39-django32: Django>=3.2,<3.3
     py39-django40: Django>=4.0,<4.1
     py39-django40: black


### PR DESCRIPTION
When Django 4.0 was released the Django team dropped support for Django 3.1.
In the next release we'll only support versions that are supported
by upstream. So we're dropping support for Django 3.1. Sadly we cannot
remove any version checks since they all impact Django 2.2 as well,
which is still supported because it's an LTS release.

Source: https://www.djangoproject.com/download/#supported-versions