### PR TITLE
Make our Django version check behaviour consistent

### DIFF
--- a/django_multitenant/backends/postgresql/base.py
+++ b/django_multitenant/backends/postgresql/base.py
@@ -134,7 +134,7 @@ class DatabaseFeatures(PostgresqlDatabaseFeatures):
 
     # For django versions before version 3.0 we set a flag that disables this
     # behaviour for all models.
-    if django.VERSION[0] < 3:
+    if django.VERSION < (3, 0):
         allows_group_by_selected_pks = False
 
 

--- a/django_multitenant/deletion.py
+++ b/django_multitenant/deletion.py
@@ -8,7 +8,7 @@ from .utils import get_current_tenant, get_tenant_filters
 
 
 def related_objects(obj, *args):
-    if django.VERSION[0] < 3 or len(args) == 2:
+    if django.VERSION < (3, 0) or len(args) == 2:
         related = args[0]
         related_model = related.related_model
         related_fields = [related.field]

--- a/django_multitenant/tests/test_models.py
+++ b/django_multitenant/tests/test_models.py
@@ -450,7 +450,7 @@ class TenantModelTest(BaseTestCase):
         self.assertEqual(tasks.count(), 150)
 
     @pytest.mark.skipif(
-        not django.VERSION < (3, 2),
+        django.VERSION >= (3, 2),
         reason="Django 3.2 changed the generated query to one that's not supported by Citus",
     )
     def test_exclude_related(self):


### PR DESCRIPTION
This changes the way we check for django versions to be either:
1. Version is below version X.Y: `django.VERSION < (X, Y)`
2. Version is equal or higher than version X.Y: `django.VERSION >= (X, Y)`