### PR TITLE
Bump to version 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, "README.md")) as f:
 
 setup(
     name="django-multitenant",
-    version="2.4.0",  # Required
+    version="3.0.0",  # Required
     description="Django Library to Implement Multi-tenant databases",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This release will do the following breaking changes:
1. Drop support for Python 2.7
2. Drop support for Django 1.11
3. Drop support for Django 3.1

And it also has the major feature of adding support for Django 4.0.

So I think a major version bump makes sense, both from a semver
perspective and a feature perspective.