### PR TITLE
Updating docs to show the importance of unsetting the tenant in a middleware

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -194,16 +194,38 @@ Where to Set the Tenant?
 
    .. code:: python
 
-    from django_multitenant.utils import set_current_tenant
+    from django_multitenant.utils import set_current_tenant, unset_current_tenant
+    from django.contrib.auth import logout
+
 
     class MultitenantMiddleware:
-        def __init__(self, get_response):
-            self.get_response = get_response
+      def __init__(self, get_response):
+         self.get_response = get_response
 
-        def __call__(self, request):
-            if request.user and not request.user.is_anonymous:
-                set_current_tenant(request.user.employee.company)
-                  return self.get_response(request)
+      def __call__(self, request):
+         if request.user and not request.user.is_anonymous:
+            if not request.user.account and not request.user.is_superuser:
+               print(
+                  "Logging out because user doesnt have account and not a superuser"
+               )
+               logout(request.user)
+
+            set_current_tenant(request.user.account)
+
+         response = self.get_response(request)
+
+         """
+         The following unsetting of the tenant is essential because of how webservers work
+         Since the tenant is set as a thread local, the thread is not killed after the request is processed
+         So after processing of the request, we need to ensure that the tenant is unset
+         Especially required if you have public users accessing the site 
+         
+         This is also essential if you have admin users not related to a tenant (not possible in actual citus env)
+         """
+         unset_current_tenant()
+
+         return response
+
 
    In your settings, you will need to update the ``MIDDLEWARE`` setting
    to include the one you created.


### PR DESCRIPTION
In the middleware example, it is assumed the user always has to have a tenant set. However, it is often better to unset the tenant in the middleware after the request is processed as it is using thread-local. As a rule of thumb, any thread-local should be cleared after request processing in a webserver because webservers reuse threads/processes.