### PR TITLE
Fix utils to not require `TENANT_USE_ASGIREF` to be defined in the host django project

### DIFF
--- a/django_multitenant/tests/test_utils.py
+++ b/django_multitenant/tests/test_utils.py
@@ -58,6 +58,7 @@ class UtilsTest(BaseTestCase):
         account = projects[0].account
 
         with self.settings(TENANT_USE_ASGIREF=True):
+            importlib.reload(sys.modules["django_multitenant.settings"])
             importlib.reload(sys.modules["django_multitenant.utils"])
 
             # Set the tenant in task
@@ -66,6 +67,7 @@ class UtilsTest(BaseTestCase):
             unset_current_tenant()
 
         with self.settings(TENANT_USE_ASGIREF=False):
+            importlib.reload(sys.modules["django_multitenant.settings"])
             importlib.reload(sys.modules["django_multitenant.utils"])
 
             # Set the tenant in task

--- a/django_multitenant/utils.py
+++ b/django_multitenant/utils.py
@@ -1,10 +1,10 @@
 import inspect
 
 from django.apps import apps
-from django.conf import settings
+from .settings import TENANT_USE_ASGIREF
 
 
-if settings.TENANT_USE_ASGIREF:
+if TENANT_USE_ASGIREF:
     # asgiref must be installed, its included with Django >= 3.0
     from asgiref.local import Local as local
 else:


### PR DESCRIPTION
Most projects using `django-multitenant` wont have `TENANT_USE_ASGIREF` defined as its a new feature. 
They also shouldnt be required to add it... should just be treated as `False` if missing.

This is an issue that was introduced by #198 

Note that this will also resolve #205 issues