### PR TITLE
Fix issue in `is_val_equal_to_tenant` leading to redundant DB calls

### DIFF
--- a/django_multitenant/tests/test_models.py
+++ b/django_multitenant/tests/test_models.py
@@ -150,6 +150,15 @@ class TenantModelTest(BaseTestCase):
                 in captured_queries.captured_queries[0]["sql"]
             )
 
+    def test_related_manager_query(self):
+        from .models import Project
+
+        account = self.account_fr
+        Project.objects.create(account=account, name=f"test_project")
+
+        with self.assertNumQueries(1):
+            list(account.projects.all())
+
     def test_prefetch_related(self):
         from .models import Project
 


### PR DESCRIPTION
As described [in this issue](https://github.com/citusdata/django-multitenant/issues/214) we want to avoid making extra queries when using related managers.

The proposed solution avoids making extra DB calls by comparing the tenant field of `val` against `self.tenant_value` instead of comparing `val` with the whole tenant object.

## Notes
`is_val_equal_to_tenant` is a bit misleading/bad naming as this function actually checks for in-equality.

I think we should do one of the following- 
-  Change the name to `is_not_equal_to_tenant` and keep the same implementation 
-  Update the logic to check for equality, keep the current name and update the condition where this is used to be negated

I can update this PR if you prefer one of these options, I wanted to keep this PR on the issue point and avoid cosmetics so didn't add these changes in advance.  
