### PR TITLE
Fix TypeError in wrap_many_related_manager_add by proper tenant_id check

### DIFF
--- a/django_multitenant/mixins.py
+++ b/django_multitenant/mixins.py
@@ -37,10 +37,13 @@ def wrap_many_related_manager_add(many_related_manager_add):
 
     def add(self, *objs, through_defaults=None):
         if hasattr(self.through, "tenant_field") and get_current_tenant():
+            tenant_field = get_tenant_column(self.through)
+            current_tenant = get_current_tenant_value()
             through_defaults = through_defaults or {}
-            through_defaults[
-                get_tenant_column(self.through)
-            ] = get_current_tenant_value()
+
+            if tenant_field not in through_defaults:
+                through_defaults[tenant_field] = current_tenant
+
         return many_related_manager_add(self, *objs, through_defaults=through_defaults)
 
     return add


### PR DESCRIPTION
Fixes issue #216 

Resolved an issue where `wrap_many_related_manager_add` would raise a `TypeError` if `tenant_id` was already set in `through_defaults`. The function now checks if `tenant_id` exists in `through_defaults` before setting it, ensuring compatibility with existing tenant contexts.