### PR TITLE
Fix _do_update signature mismatch for Django 6.x

### DIFF
--- a/django_multitenant/mixins.py
+++ b/django_multitenant/mixins.py
@@ -143,7 +143,7 @@ class TenantModelMixin:
         return super().__setattr__(attrname, val)
 
     # pylint: disable=too-many-arguments
-    def _do_update(self, base_qs, using, pk_val, values, update_fields, forced_update):
+    def _do_update(self, base_qs, using, pk_val, values, update_fields, forced_update, *args, **kwargs):
         # adding tenant filters for save
         # Citus requires tenant_id filters for update, hence doing this below change.
 
@@ -165,7 +165,7 @@ class TenantModelMixin:
             logger.warning(empty_tenant_message)
 
         return super()._do_update(
-            base_qs, using, pk_val, values, update_fields, forced_update
+            base_qs, using, pk_val, values, update_fields, forced_update, *args, **kwargs
         )
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
This PR updates TenantModelMixin._do_update to accept *args, **kwargs so it remains compatible with Django 6.0+, which added an extra argument to _do_update.

Prevents TypeError: ... takes 7 positional arguments but 8 were given.

Backward compatible with older Django versions.

Future‑proof against further changes in Django’s internal _do_update signature.

Fixes #261  